### PR TITLE
Add legal disclosure (Impressum) page

### DIFF
--- a/content/impressum.md
+++ b/content/impressum.md
@@ -12,7 +12,7 @@ Friedrich-Schiller Universität Jena
 
 Leutragraben 1
 
-97743 Jena
+07743 Jena
 
 **Contact:**
 

--- a/content/impressum.md
+++ b/content/impressum.md
@@ -8,7 +8,7 @@ title: "Legal Disclosure"
 
 Kevin Maik Jablonka
 
-Friedrich-Schiller Universität Jena
+Friedrich-Schiller-Universität Jena
 
 Leutragraben 1
 

--- a/content/impressum.md
+++ b/content/impressum.md
@@ -1,0 +1,33 @@
+---
+title: "Legal Disclosure"
+---
+
+# Legal Disclosure
+
+## Information in accordance with section 5 TMG
+
+Kevin Maik Jablonka
+
+Friedrich-Schiller Universität Jena
+
+Leutragraben 1
+
+97743 Jena
+
+**Contact:**
+
+E-Mail: kevin.jablonka [at] uni-jena.de
+
+## Disclaimer
+
+### Accountability for content
+
+The contents of my pages have been created with the utmost care. However, I cannot guarantee the contents’ accuracy, completeness or topicality. According to statutory provisions, I am furthermore responsible for my own content on these web pages. In this context, please note that I am accordingly not obliged to monitor merely the transmitted or saved information of third parties, or investigate circumstances pointing to illegal activity. My obligations to remove or block the use of information under generally applicable laws remain unaffected by this as per §§ 8 to 10 of the Telemedia Act (TMG).
+
+### Accountability for links
+
+Responsibility for the content of external links (to web pages of third parties) lies solely with the operators of the linked pages. No violations were evident to me at the time of linking. Should any legal infringement become known to me, I will remove the respective link immediately.
+
+### Copyright
+
+My web pages and their contents are subject to German copyright law. Unless expressly permitted by law (§ 44a et seq. of the copyright law), every form of utilizing, reproducing or processing works subject to copyright protection on my web pages requires the prior consent of the respective owner of the rights. Individual reproductions of a work are allowed only for private use, so must not serve either directly or indirectly for earnings. Unauthorized utilization of copyrighted works is punishable (§ 106 of the copyright law).

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,0 +1,15 @@
+<footer id="footer">
+  <div class="footer-left">
+    Copyright  &copy; {{ now.Format "2006" }} {{ if .Site.Copyright }} {{ print .Site.Copyright | markdownify }} {{ else }} {{ print .Site.Title }} {{ end }}
+    &middot; <a href="{{ "impressum" | relURL }}">legal disclosure</a>
+  </div>
+  <div class="footer-right">
+    <nav>
+      <ul>
+        {{ range .Site.Menus.main }}
+        <li><a href="{{ .URL }}">{{ .Name }}</a></li>
+        {{ end }}
+      </ul>
+    </nav>
+  </div>
+</footer>


### PR DESCRIPTION
## What

Adds a legal disclosure / Impressum to the site.

- **`content/impressum.md`** — TMG §5 legal disclosure page, rendered at `/impressum/`. Contains the operator information, contact, and the three disclaimer sections (accountability for content, accountability for links, copyright).
- **`layouts/partials/footer.html`** — cactus theme footer override that adds a `legal disclosure` link next to the copyright line.

## Why the footer

The cactus footer already renders the main menu, and the top nav is fairly crowded. Linking the Impressum only from the footer (the conventional location) makes it reachable site-wide without adding to the top nav.

## Verification

Built locally with Hugo 0.128.0 extended (the version CI uses):
- `/impressum/index.html` renders the full text.
- The footer link (`./impressum`, relative since `relativeURLs = true`) appears on every page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a legal disclosure (Impressum) page and link it site-wide from the footer.

New Features:
- Introduce a Legal Disclosure / Impressum content page rendered at /impressum/.
- Add a footer link to the legal disclosure page alongside the existing copyright information.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Legal Disclosure page containing organizational information, contact details, and liability disclaimers
  * Added a footer to all pages displaying the current year, copyright notice, a link to legal disclosure, and the main site navigation menu

<!-- end of auto-generated comment: release notes by coderabbit.ai -->