### PR TITLE
Publications: pillar anchor map, multi-thread classification, type filters

### DIFF
--- a/.github/workflows/build-publications.yml
+++ b/.github/workflows/build-publications.yml
@@ -31,10 +31,8 @@ jobs:
 
       - name: Rebuild data/publications.json
         env:
-          # OPENAI_API_KEY -> text-embedding-3-large for the landscape layout
-          # ANTHROPIC_API_KEY -> Claude classifies each paper into a research thread
-          # Both optional: the script falls back gracefully if a key is absent.
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          # ANTHROPIC_API_KEY -> Claude assigns each paper to one or two threads.
+          # Optional: without it the script falls back to a keyword heuristic.
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: python publications/build.py ${{ inputs.force && '--force' || '' }}
 

--- a/content/publications.md
+++ b/content/publications.md
@@ -2,9 +2,10 @@
 title: "publications"
 ---
 
-a map of what we work on. each point is a paper, placed by an embedding of its
-abstract and coloured by one of our four research threads — **perception,
-reasoning, evaluation, action**. hover to peek, click to jump to the paper. the
-list below carries the abstracts.
+a map of what we work on, organised around our four research threads —
+**perception, reasoning, evaluation, action** — plus the community work around
+them. each paper sits on the thread(s) it belongs to; papers that span two
+threads sit between them. hover to peek, click to jump to the paper, and filter
+the list below by type or thread.
 
 {{< publications >}}

--- a/data/publications.json
+++ b/data/publications.json
@@ -1,29 +1,34 @@
 {
-  "topics": [
+  "threads": [
     {
       "id": 0,
       "name": "perception",
-      "color": "#2C6E91"
+      "color": "#2C6E91",
+      "description": "understanding chemistry from what we actually measure — spectra and characterization data, and the knowledge buried in the literature."
     },
     {
       "id": 1,
       "name": "reasoning",
-      "color": "#8E5BA6"
+      "color": "#8E5BA6",
+      "description": "combining formal rules with the tacit heuristics expert chemists use, so models reason rather than pattern-match."
     },
     {
       "id": 2,
       "name": "evaluation",
-      "color": "#A43830"
+      "color": "#A43830",
+      "description": "honestly measuring what models and agents can really do — and where they only look capable."
     },
     {
       "id": 3,
       "name": "action",
-      "color": "#5B8C5A"
+      "color": "#5B8C5A",
+      "description": "predictions experimentalists can act on, starting from the recipes and processing conditions they control."
     },
     {
       "id": 4,
-      "name": "unclassified",
-      "color": "#9AA0A6"
+      "name": "community",
+      "color": "#C98A3C",
+      "description": "perspectives, education, and community-building around AI for chemistry."
     }
   ],
   "papers": [
@@ -42,12 +47,12 @@
       "year": 2026,
       "abstract": "A growing body of work pursues AI scientists capable of end-to-end autonomous scientific discovery. This position paper argues that although they already function as co-scientists, agentic AI scientists are not built for autonomous scientific discovery. We identify the following challenges in building and deploying autonomous AI scientists: (1) Problem selection is influenced by the McNamara fallacy; (2) Agents are built on large language models (LLMs) whose training corpora omit tacit procedural and failure knowledge of laboratory practice; (3) Preference optimisation during post-training compresses output diversity toward consensus; and (4) Most scientific benchmarks measure single-turn prediction accuracy and lack feedback from physical experiments back to the computational model. These challenges are not just questions of scale and scaffolding; they require revisiting fundamental design choices. To build truly autonomous AI scientists, we recommend the use of scientific simulations as verifiers for training, the design of persistent world models that represent the shifting objectives governing real investigations, the establishment of a centralized preregistration repository for all AI-generated hypotheses, and application driven by scientific need rather than tool affordance.",
       "citations": null,
-      "role": "coauthor",
       "highlighted": false,
-      "pillar": "evaluation",
-      "topic": 2,
-      "x": 19.2985,
-      "y": -7.3753
+      "pillars": [
+        "evaluation"
+      ],
+      "type": "preprint",
+      "pillar_auto": true
     },
     {
       "doi": "10.48550/arXiv.2604.18805",
@@ -67,12 +72,12 @@
       "year": 2026,
       "abstract": "Large language model (LLM)-based systems are increasingly deployed to conduct scientific research autonomously, yet whether their reasoning adheres to the epistemic norms that make scientific inquiry self-correcting is poorly understood. Here, we evaluate LLM-based scientific agents across eight domains, spanning workflow execution to hypothesis-driven inquiry, through more than 25,000 agent runs and two complementary lenses: (i) a systematic performance analysis that decomposes the contributions of the base model and the agent scaffold, and (ii) a behavioral analysis of the epistemological structure of agent reasoning. We observe that the base model is the primary determinant of both performance and behavior, accounting for 41.4% of explained variance versus 1.5% for the scaffold. Across all configurations, evidence is ignored in 68% of traces, refutation-driven belief revision occurs in 26%, and convergent multi-test evidence is rare. The same reasoning pattern appears whether the agent executes a computational workflow or conducts hypothesis-driven inquiry. They persist even when agents receive near-complete successful reasoning trajectories as context, and the resulting unreliability compounds across repeated trials in epistemically demanding domains. Thus, current LLM-based agents execute scientific workflows but do not exhibit the epistemic patterns that characterize scientific reasoning. Outcome-based evaluation cannot detect these failures, and scaffold engineering alone cannot repair them. Until reasoning itself becomes a training target, the scientific knowledge produced by such agents cannot be justified by the process that generated it.",
       "citations": 5,
-      "role": "corresponding",
       "highlighted": false,
-      "pillar": "evaluation",
-      "topic": 2,
-      "x": 18.5481,
-      "y": -7.4213
+      "pillars": [
+        "evaluation"
+      ],
+      "type": "preprint",
+      "pillar_auto": true
     },
     {
       "doi": "10.48550/arXiv.2601.17807",
@@ -103,12 +108,12 @@
       "year": 2026,
       "abstract": "Scientific discovery is severely bottlenecked by the inability of manual curation to keep pace with exponential publication rates. This creates a widening knowledge gap. This is especially stark in photovoltaics, where the leading database for perovskite solar cells has been stagnant since 2021 despite massive ongoing research output. Here, we resolve this challenge by establishing an autonomous, self-updating living database (PERLA). Our pipeline integrates large language models with physics-aware validation to extract complex device data from the continuous literature stream, achieving human-level precision (>90%) and eliminating annotator variance. By employing this system on the previously inaccessible post-2021 literature, we uncover critical evolutionary trends hidden by data lag: the field has decisively shifted toward inverted architectures employing self-assembled monolayers and formamidinium-rich compositions, driving a clear trajectory of sustained voltage loss reduction. PERLA transforms static publications into dynamic knowledge resources that enable data-driven discovery to operate at the speed of publication.",
       "citations": null,
-      "role": "corresponding",
       "highlighted": false,
-      "pillar": "perception",
-      "topic": 0,
-      "x": 19.1377,
-      "y": -9.7207
+      "pillars": [
+        "perception"
+      ],
+      "type": "preprint",
+      "pillar_auto": true
     },
     {
       "doi": "10.48550/arXiv.2602.04696",
@@ -122,12 +127,13 @@
       "year": 2026,
       "abstract": "Molecular representations are inherently task-dependent, yet most pre-trained molecular encoders are not. Task conditioning promises representations that reorganize based on task descriptions, but existing approaches rely on expensive labeled data. We show that weak supervision on programmatically derived molecular motifs is sufficient. Our Adaptive Chemical Embedding Model (ACE-Mol) learns from hundreds of motifs paired with natural language descriptors that are cheap to compute, trivial to scale. Conventional encoders slowly search the embedding space for task-relevant structure, whereas ACE-Mol immediately aligns its representations with the task. ACE-Mol achieves state-of-the-art performance across molecular property prediction benchmarks with interpretable, chemically meaningful representations.",
       "citations": null,
-      "role": "corresponding",
       "highlighted": false,
-      "pillar": "reasoning",
-      "topic": 1,
-      "x": 17.9014,
-      "y": -9.2874
+      "pillars": [
+        "reasoning",
+        "action"
+      ],
+      "type": "preprint",
+      "pillar_auto": true
     },
     {
       "doi": "10.48550/arXiv.2602.17730",
@@ -140,12 +146,12 @@
       "year": 2026,
       "abstract": "Machine learning can accelerate materials discovery. Models perform impressively on many benchmarks. However, strong benchmark performance does not imply that a model learned chemistry. I test a concrete alternative hypothesis: that property prediction can be driven by bibliographic confounding. Across five tasks spanning MOFs (thermal and solvent stability), perovskite solar cells (efficiency), batteries (capacity), and TADF emitters (emission wavelength), models trained on standard chemical descriptors predict author, journal, and publication year well above chance. When these predicted metadata (\"bibliographic fingerprints\") are used as the sole input to a second model, performance is sometimes competitive with conventional descriptor-based predictors. These results show that many datasets do not rule out non-chemical explanations of success. Progress requires routine falsification tests (e.g., group/time splits and metadata ablations), datasets designed to resist spurious correlations, and explicit separation of two goals: predictive utility versus evidence of chemical understanding.",
       "citations": null,
-      "role": "corresponding",
       "highlighted": false,
-      "pillar": "evaluation",
-      "topic": 2,
-      "x": 19.0327,
-      "y": -9.1635
+      "pillars": [
+        "evaluation"
+      ],
+      "type": "preprint",
+      "pillar_auto": true
     },
     {
       "doi": "10.1038/s41467-026-73846-y",
@@ -160,12 +166,12 @@
       "year": 2026,
       "abstract": "Elucidating molecular structures from spectroscopic data remains one of chemistry’s most fundamental challenges, typically requiring extensive expert knowledge and manual interpretation of multiple analytical techniques. This is because the structure elucidation problem often has degenerate solutions for a limited set of experimental data. Existing computational approaches are limited to single spectroscopic modalities, require extensive manual preprocessing, and lack the confidence estimates and context necessary for practical application. Here we present , a framework that combines contrastive learning with evolutionary algorithms to automate structure elucidation directly from raw, multimodal spectroscopic data. By aligning embeddings across NMR, infrared, and mass spectrometry, mimics how experts use multiple spectroscopic lenses while providing calibrated confidence scores and relevant database context. On challenging molecular identification tasks, matches expert chemist performance in head-to-head comparisons in a pilot study. The system successfully identifies incorrect structure assignments in published literature and adapts to new chemical domains without retraining by updating its reference database. Our approach demonstrates how synergistic combination of machine learning paradigms can solve analytical bottlenecks that have constrained chemical discovery.",
       "citations": 0,
-      "role": "corresponding",
       "highlighted": false,
-      "pillar": "perception",
-      "topic": 0,
-      "x": 18.0212,
-      "y": -8.873
+      "pillars": [
+        "perception"
+      ],
+      "type": "peer-reviewed",
+      "pillar_auto": true
     },
     {
       "doi": "10.1021/acs.chemrev.5c00583",
@@ -186,12 +192,12 @@
       "year": 2026,
       "abstract": "Data-driven techniques have a large potential to transform and accelerate the chemical sciences. However, chemical sciences also pose the unique challenge of very diverse, small, fuzzy data sets that are difficult to leverage in conventional machine learning approaches. A new class of models, which can be summarized under the term general-purpose models (GPMs) such as large language models, has shown the ability to solve tasks they have not been directly trained on, and to flexibly operate with low amounts of data in different formats. In this review, we discuss the fundamental building principles of GPMs and review recent and emerging applications of those models in the chemical sciences. While many of these applications are still in the prototype phase, we expect that the increasing interest in GPMs will make many of them mature in the coming years.",
       "citations": 4,
-      "role": "corresponding",
       "highlighted": false,
-      "pillar": "reasoning",
-      "topic": 1,
-      "x": 17.1524,
-      "y": -8.5882
+      "pillars": [
+        "reasoning"
+      ],
+      "type": "peer-reviewed",
+      "pillar_auto": true
     },
     {
       "doi": "10.1016/j.carbpol.2026.124890",
@@ -214,12 +220,12 @@
       "year": 2026,
       "abstract": "The hydrophobic, pH-labile, and biodegradable acetalated dextran (Ac(e)Dex) is a promising material for drug delivery in nanomedicine. However, fundamental knowledge about the structure-property relationships is still missing, which hinders its application in preclinical and clinical trials. In this study, we synthesized a library of 36 Ac(e)Dex derivatives with different molar masses, types, and degrees of functionalization. A high-throughput formulation screening (> 1000 formulations) was conducted using a liquid handling robot optimizing the concentration of polymer, the solvent, and the addition of additives. Selected formulations were scaled up and evaluated for their stability. To further correlate polymer properties with stability, a machine learning (ML) model was developed, providing a predictive tool for Ac(e)Dex nanoparticle degradation based on synthesis/formulation data. The novelty of this work lies in the integrated synthesis-to-prediction pipeline combining controlled polymer synthesis, high-throughput formulation, and ML-based stability modeling, rather than introducing new chemical mechanisms. By eludicating how structural parameters (molar mass, type, and degree of functionalization) influence formulation properties (i.e., size, dispersity, repeatability) and particle stability, this work enables standardized comparisons of Ac(e)Dex between different studies and supports its future preclinical development.",
       "citations": 1,
-      "role": "coauthor",
       "highlighted": false,
-      "pillar": "action",
-      "topic": 3,
-      "x": 18.5469,
-      "y": -9.9732
+      "pillars": [
+        "action"
+      ],
+      "type": "peer-reviewed",
+      "pillar_auto": true
     },
     {
       "doi": "10.48550/arXiv.2605.13826",
@@ -233,12 +239,12 @@
       "year": 2026,
       "abstract": "Scientific machine learning reports predictive performance. It does not report whether the same prediction would survive a different draw of training data. Across $9$ chemistry benchmarks, two classifiers trained on independent bootstraps of the same training set agree on aggregate accuracy to within $1.3\\text{--}4.2$ percentage points but disagree on the class label of $8.0\\text{--}21.8\\%$ of test molecules. We call this gap \\emph{cross-sample prediction churn}. The standard parameter-side techniques (deep ensembles, MC dropout, stochastic weight averaging) do not reduce this gap; two data-side methods do. The first is $K$-bootstrap bagging, which cuts the rate $40\\text{--}54\\%$ on every dataset at no accuracy cost ($K{\\times}$-ERM compute). The second is \\emph{twin-bootstrap}, our proposal: two networks trained jointly on independent bootstraps with a sym-KL consistency loss between their predictions, which at matched $2{\\times}$-ERM compute reduces churn a further median $45\\%$ beyond bagging-$K{=}2$. Cross-sample prediction churn deserves a column alongside predictive performance in scientific-ML benchmark reports, because without it the parameter-side and data-side methods are indistinguishable on the metric they actually differ on.",
       "citations": null,
-      "role": "corresponding",
       "highlighted": false,
-      "pillar": "evaluation",
-      "topic": 2,
-      "x": 19.5796,
-      "y": -9.2338
+      "pillars": [
+        "evaluation"
+      ],
+      "type": "preprint",
+      "pillar_auto": true
     },
     {
       "doi": "10.48550/arXiv.2601.21618",
@@ -253,12 +259,12 @@
       "year": 2026,
       "abstract": "Counting should not depend on what is being counted; more generally, any algorithm's behavior should be invariant to the semantic content of its arguments. We introduce WhatCounts to test this property in isolation. Unlike prior work that conflates semantic sensitivity with reasoning complexity or prompt variation, WhatCounts is atomic: count items in an unambiguous, delimited list with no duplicates, distractors, or reasoning steps for different semantic types. Frontier LLMs show over 40% accuracy variation depending solely on what is being counted - cities versus chemicals, names versus symbols. Controlled ablations rule out confounds. The gap is semantic, and it shifts unpredictably with small amounts of unrelated fine-tuning. LLMs do not implement algorithms; they approximate them, and the approximation is argument-dependent. As we show with an agentic example, this has implications beyond counting: any LLM function may carry hidden dependencies on the meaning of its inputs.",
       "citations": null,
-      "role": "corresponding",
       "highlighted": false,
-      "pillar": "evaluation",
-      "topic": 2,
-      "x": 17.3799,
-      "y": -7.4382
+      "pillars": [
+        "evaluation"
+      ],
+      "type": "preprint",
+      "pillar_auto": true
     },
     {
       "doi": "10.1038/s41557-025-01815-x",
@@ -305,12 +311,13 @@
       "year": 2025,
       "abstract": "Large language models (LLMs) have gained widespread interest owing to their ability to process human language and perform tasks on which they have not been explicitly trained. However, we possess only a limited systematic understanding of the chemical capabilities of LLMs, which would be required to improve models and mitigate potential harm. Here we introduce ChemBench, an automated framework for evaluating the chemical knowledge and reasoning abilities of state-of-the-art LLMs against the expertise of chemists. We curated more than 2,700 question–answer pairs, evaluated leading open- and closed-source LLMs and found that the best models, on average, outperformed the best human chemists in our study. However, the models struggle with some basic tasks and provide overconfident predictions. These findings reveal LLMs’ impressive chemical capabilities while emphasizing the need for further research to improve their safety and usefulness. They also suggest adapting chemistry education and show the value of benchmarking frameworks for evaluating LLMs in specific domains.",
       "citations": 88,
-      "role": "corresponding",
       "highlighted": false,
-      "pillar": "evaluation",
-      "topic": 2,
-      "x": 16.7249,
-      "y": -9.0245
+      "pillars": [
+        "evaluation",
+        "reasoning"
+      ],
+      "type": "peer-reviewed",
+      "pillar_auto": true
     },
     {
       "doi": "10.1038/s41557-025-01865-1",
@@ -323,12 +330,13 @@
       "year": 2025,
       "abstract": "The findings reveal that leading LLMs outperform expert chemists in chemical knowledge and reasoning across diverse topics, while highlighting critical limitations that require further development.",
       "citations": 3,
-      "role": "corresponding",
       "highlighted": false,
-      "pillar": "evaluation",
-      "topic": 2,
-      "x": 16.3362,
-      "y": -7.7378
+      "pillars": [
+        "evaluation",
+        "reasoning"
+      ],
+      "type": "editorial",
+      "pillar_auto": true
     },
     {
       "doi": "10.1039/d4sc04401k",
@@ -390,12 +398,13 @@
       "year": 2025,
       "abstract": "We studied the performance of fine-tuning open-source LLMs for a range of different chemical questions. We benchmark their performances against “traditional” machine learning models and find that, in most cases, the fine-tuning approach is superior.",
       "citations": 30,
-      "role": "first",
       "highlighted": false,
-      "pillar": "evaluation",
-      "topic": 2,
-      "x": 16.5992,
-      "y": -8.4209
+      "pillars": [
+        "action",
+        "reasoning"
+      ],
+      "type": "peer-reviewed",
+      "pillar_auto": true
     },
     {
       "doi": "10.48550/arXiv.2505.12534",
@@ -422,12 +431,12 @@
       "year": 2025,
       "abstract": "Foundation models have shown remarkable success across scientific domains, yet their impact in chemistry remains limited due to the absence of diverse, large-scale, high-quality datasets that reflect the field's multifaceted nature. We present the ChemPile, an open dataset containing over 75 billion tokens of curated chemical data, specifically built for training and evaluating general-purpose models in the chemical sciences. The dataset mirrors the human learning journey through chemistry -- from educational foundations to specialized expertise -- spanning multiple modalities and content types including structured data in diverse chemical representations (SMILES, SELFIES, IUPAC names, InChI, molecular renderings), scientific and educational text, executable code, and chemical images. ChemPile integrates foundational knowledge (textbooks, lecture notes), specialized expertise (scientific articles and language-interfaced data), visual understanding (molecular structures, diagrams), and advanced reasoning (problem-solving traces and code) -- mirroring how human chemists develop expertise through diverse learning materials and experiences. Constructed through hundreds of hours of expert curation, the ChemPile captures both foundational concepts and domain-specific complexity. We provide standardized training, validation, and test splits, enabling robust benchmarking. ChemPile is openly released via HuggingFace with a consistent API, permissive license, and detailed documentation. We hope the ChemPile will serve as a catalyst for chemical AI, enabling the development of the next generation of chemical foundation models.",
       "citations": null,
-      "role": "corresponding",
       "highlighted": false,
-      "pillar": "reasoning",
-      "topic": 1,
-      "x": 17.3152,
-      "y": -9.9324
+      "pillars": [
+        "reasoning"
+      ],
+      "type": "peer-reviewed",
+      "pillar_auto": true
     },
     {
       "doi": "10.1039/d4cs00913d",
@@ -447,12 +456,12 @@
       "year": 2025,
       "abstract": "Large language models (LLMs) allow for the extraction of structured data from unstructured sources, such as scientific papers, with unprecedented accuracy and performance.",
       "citations": 72,
-      "role": "corresponding",
       "highlighted": false,
-      "pillar": "perception",
-      "topic": 0,
-      "x": 16.7744,
-      "y": -7.9235
+      "pillars": [
+        "perception"
+      ],
+      "type": "peer-reviewed",
+      "pillar_auto": true
     },
     {
       "doi": "10.1016/j.commatsci.2025.114041",
@@ -467,12 +476,12 @@
       "year": 2025,
       "abstract": "",
       "citations": null,
-      "role": "corresponding",
       "highlighted": false,
-      "pillar": "evaluation",
-      "topic": 2,
-      "x": 19.453,
-      "y": -8.7715
+      "pillars": [
+        "evaluation"
+      ],
+      "type": "peer-reviewed",
+      "pillar_auto": true
     },
     {
       "doi": "10.1039/d5dd00109a",
@@ -489,12 +498,12 @@
       "year": 2025,
       "abstract": "MOFChecker, a package for MOF duplicate detection, geometric and charge error checking, and structure correction.",
       "citations": 14,
-      "role": "coauthor",
       "highlighted": false,
-      "pillar": "action",
-      "topic": 3,
-      "x": 18.4849,
-      "y": -9.2542
+      "pillars": [
+        "perception"
+      ],
+      "type": "peer-reviewed",
+      "pillar_auto": true
     },
     {
       "doi": "10.1088/2632-2153/ae0d5d",
@@ -513,12 +522,12 @@
       "year": 2025,
       "abstract": "The intersection of artificial intelligence and materials science has become increasingly interconnected, driving ambitious research initiatives across both fields. Since 2022, the AI for accelerated materials design (AI4Mat) workshops have provided a leading venue for showcasing cutting-edge advances in this emerging interdisciplinary domain while fostering critical discussions about the most pressing scientific and technical challenges. In 2024, AI4Mat hosted workshops at BOKU University and NeurIPS 2024, attracting researchers and practitioners from academia, industry, and government institutions worldwide. These workshops explored diverse research areas currently shaping the field, with participants engaging in comprehensive discussions that addressed the intersection’s most significant challenges from scientific, technical, and commercial perspectives. Through this holistic approach, AI4Mat’s 2024 workshops successfully illuminated the multifaceted nature of AI-driven materials research, highlighting both current achievements and future opportunities in this rapidly evolving field. In this article, the AI4Mat-2024 organizing committee presents key insights from our workshops and community discussions, outlining critical challenges in this emerging field while summarizing the latest advances in AI-accelerated materials design. We examine persistent challenges around data creation and reproducibility, alongside the growing commercial interest in developing new markets and optimization materials production processes at scale. The article also highlights significant research breakthroughs showcased at AI4Mat, including the application of large language models to accelerate materials science tasks, the development of sophisticated generative models for materials discovery, and the growing demand for interpretable AI methodologies that provide transparent insights into materials behavior.",
       "citations": 1,
-      "role": "coauthor",
       "highlighted": false,
-      "pillar": "unclassified",
-      "topic": 4,
-      "x": 19.0701,
-      "y": -8.3107
+      "pillars": [
+        "community"
+      ],
+      "type": "editorial",
+      "pillar_auto": true
     },
     {
       "doi": "10.1038/s41524-025-01823-y",
@@ -532,12 +541,12 @@
       "year": 2025,
       "abstract": "Digital polymer chemistry leverages computational methods to design and optimize polymer materials. While there have been advances in using machine learning to accelerate the design of polymers, the field is hampered by the lack of standards, which precludes comparability and makes it difficult to build on top of prior work. To address this gap, we introduce PolyMetriX, an open-source Python library designed to facilitate the entire polymer informatics workflow—from obtaining data to training models. PolyMetriX provides curated polymer property datasets, and novel featurization techniques that extract hierarchical structural information at the full polymer, backbone, and sidechain levels. Additionally, it incorporates polymer-specific data splitting strategies to ensure robust model generalization. PolyMetriX enhances the predictive performance of models while improving reproducibility in digital polymer chemistry.",
       "citations": 7,
-      "role": "corresponding",
       "highlighted": false,
-      "pillar": "action",
-      "topic": 3,
-      "x": 18.061,
-      "y": -9.9028
+      "pillars": [
+        "action"
+      ],
+      "type": "peer-reviewed",
+      "pillar_auto": true
     },
     {
       "doi": "10.1038/s43588-025-00836-3",
@@ -557,12 +566,13 @@
       "year": 2025,
       "abstract": "Recent advancements in artificial intelligence have sparked interest in scientific assistants that could support researchers across the full spectrum of scientific workflows, from literature review to experimental design and data analysis. A key capability for such systems is the ability to process and reason about scientific information in both visual and textual forms—from interpreting spectroscopic data to understanding laboratory set-ups. Here we introduce MaCBench, a comprehensive benchmark for evaluating how vision language models handle real-world chemistry and materials science tasks across three core aspects: data extraction, experimental execution and results interpretation. Through a systematic evaluation of leading models, we find that although these systems show promising capabilities in basic perception tasks—achieving near-perfect performance in equipment identification and standardized data extraction—they exhibit fundamental limitations in spatial reasoning, cross-modal information synthesis and multi-step logical inference. Our insights have implications beyond chemistry and materials science, suggesting that developing reliable multimodal AI scientific assistants may require advances in curating suitable training data and approaches to training those models.",
       "citations": 51,
-      "role": "corresponding",
       "highlighted": false,
-      "pillar": "evaluation",
-      "topic": 2,
-      "x": 18.3374,
-      "y": -8.3481
+      "pillars": [
+        "evaluation",
+        "perception"
+      ],
+      "type": "peer-reviewed",
+      "pillar_auto": true
     },
     {
       "doi": "10.1038/s41570-025-00750-2",
@@ -576,12 +586,12 @@
       "year": 2025,
       "abstract": "This work proposes a framework for collaboration between artificial intelligence and domain experts to genuinely accelerate discovery and finds that current practices tend to reward incremental improvements in benchmark performance.",
       "citations": 6,
-      "role": "corresponding",
       "highlighted": false,
-      "pillar": "unclassified",
-      "topic": 4,
-      "x": 19.1788,
-      "y": -7.7055
+      "pillars": [
+        "community"
+      ],
+      "type": "editorial",
+      "pillar_auto": true
     },
     {
       "doi": "10.1038/s43588-025-00871-0",
@@ -595,12 +605,13 @@
       "year": 2025,
       "abstract": "Evaluation of leading VLMs reveals that they excel at basic scientific tasks such as equipment identification, but struggle with spatial reasoning and multistep analysis — a limitation for autonomous scientific discovery.",
       "citations": 1,
-      "role": "corresponding",
       "highlighted": false,
-      "pillar": "evaluation",
-      "topic": 2,
-      "x": 18.0358,
-      "y": -7.603
+      "pillars": [
+        "evaluation",
+        "perception"
+      ],
+      "type": "editorial",
+      "pillar_auto": true
     },
     {
       "doi": "10.1016/j.chempr.2024.10.010",
@@ -624,12 +635,12 @@
       "year": 2024,
       "abstract": "",
       "citations": 4,
-      "role": "coauthor",
       "highlighted": false,
-      "pillar": "unclassified",
-      "topic": 4,
-      "x": 17.0149,
-      "y": -9.6532
+      "pillars": [
+        "community"
+      ],
+      "type": "editorial",
+      "pillar_auto": true
     },
     {
       "doi": "10.48550/arXiv.2406.17295",
@@ -644,12 +655,13 @@
       "year": 2024,
       "abstract": "Predicting properties from coordinate-category data -- sets of vectors paired with categorical information -- is fundamental to computational science. In materials science, this challenge manifests as predicting properties like formation energies or elastic moduli from crystal structures comprising atomic positions (vectors) and element types (categorical information). While large language models (LLMs) have increasingly been applied to such tasks, with researchers encoding structural data as text, optimal strategies for achieving reliable predictions remain elusive. Here, we report fundamental limitations in LLM's ability to learn from coordinate information in coordinate-category data. Through systematic experiments using synthetic datasets with tunable coordinate and category contributions, combined with a comprehensive benchmarking framework (MatText) spanning multiple representations and model scales, we find that LLMs consistently fail to capture coordinate information while excelling at category patterns. This geometric blindness persists regardless of model size (up to 70B parameters), dataset scale (up to 2M structures), or text representation strategy. Our findings suggest immediate practical implications: for materials property prediction tasks dominated by structural effects, specialized geometric architectures consistently outperform LLMs by significant margins, as evidenced by a clear \"GNN-LM wall\" in performance benchmarks. Based on our analysis, we provide concrete guidelines for architecture selection in scientific machine learning, while highlighting the critical importance of understanding model inductive biases when tackling scientific prediction problems.",
       "citations": null,
-      "role": "corresponding",
       "highlighted": false,
-      "pillar": "action",
-      "topic": 3,
-      "x": 17.5347,
-      "y": -8.0629
+      "pillars": [
+        "evaluation",
+        "action"
+      ],
+      "type": "preprint",
+      "pillar_auto": true
     },
     {
       "doi": "10.1038/s42256-023-00788-1",
@@ -665,12 +677,13 @@
       "year": 2024,
       "abstract": "Machine learning has transformed many fields and has recently found applications in chemistry and materials science. The small datasets commonly found in chemistry sparked the development of sophisticated machine learning approaches that incorporate chemical knowledge for each application and, therefore, require specialized expertise to develop. Here we show that GPT-3, a large language model trained on vast amounts of text extracted from the Internet, can easily be adapted to solve various tasks in chemistry and materials science by fine-tuning it to answer chemical questions in natural language with the correct answer. We compared this approach with dedicated machine learning models for many applications spanning the properties of molecules and materials to the yield of chemical reactions. Surprisingly, our fine-tuned version of GPT-3 can perform comparably to or even outperform conventional machine learning techniques, in particular in the low-data limit. In addition, we can perform inverse design by simply inverting the questions. The ease of use and high performance, especially for small datasets, can impact the fundamental approach to using machine learning in the chemical and material sciences. In addition to a literature search, querying a pre-trained large language model might become a routine way to bootstrap a project by leveraging the collective knowledge encoded in these foundation models, or to provide a baseline for predictive tasks.",
       "citations": 379,
-      "role": "first",
       "highlighted": false,
-      "pillar": "action",
-      "topic": 3,
-      "x": 17.3702,
-      "y": -9.013
+      "pillars": [
+        "action",
+        "reasoning"
+      ],
+      "type": "peer-reviewed",
+      "pillar_auto": true
     },
     {
       "doi": "10.1021/acscentsci.3c00500",
@@ -698,12 +711,12 @@
       "year": 2024,
       "abstract": "",
       "citations": 4,
-      "role": "coauthor",
       "highlighted": false,
-      "pillar": "unclassified",
-      "topic": 4,
-      "x": 18.8791,
-      "y": -7.1421
+      "pillars": [
+        "community"
+      ],
+      "type": "editorial",
+      "pillar_auto": true
     },
     {
       "doi": "10.1039/d3dd00113j",
@@ -768,12 +781,12 @@
       "year": 2023,
       "abstract": "We report the findings of a hackathon focused on exploring the diverse applications of large language models in molecular and materials science.",
       "citations": 177,
-      "role": "corresponding",
       "highlighted": false,
-      "pillar": "reasoning",
-      "topic": 1,
-      "x": 16.1064,
-      "y": -8.3725
+      "pillars": [
+        "community"
+      ],
+      "type": "peer-reviewed",
+      "pillar_auto": true
     }
   ]
 }

--- a/layouts/shortcodes/publications.html
+++ b/layouts/shortcodes/publications.html
@@ -1,98 +1,80 @@
 {{- $data := .Site.Data.publications -}}
 <style>
-    .pub-landscape {
-        width: 100%;
-        height: 480px;
-        margin: 1.5rem 0 0.5rem;
-        border: 1px solid var(--border-color, #E0E0E0);
-        border-radius: 6px;
-    }
-    .pub-hint {
-        font-size: 0.8rem;
-        color: var(--secondary-color, #666);
-        margin: 0 0 2rem;
-    }
-    .pub-filters {
-        display: flex;
-        flex-wrap: wrap;
-        gap: 0.5rem;
-        margin: 1.5rem 0 1rem;
-        align-items: center;
-    }
-    .pub-filter {
-        font-family: "JetBrains Mono", monospace;
-        font-size: 0.8rem;
-        padding: 0.25rem 0.7rem;
-        border: 1px solid var(--border-color, #E0E0E0);
-        border-radius: 999px;
-        background: none;
-        color: var(--secondary-color, #666);
-        cursor: pointer;
-    }
-    .pub-filter.active {
-        background: var(--primary-color, #A43830);
-        border-color: var(--primary-color, #A43830);
-        color: #fff;
-    }
+    .pub-landscape { width: 100%; height: 520px; margin: 1.5rem 0 0.5rem;
+        border: 1px solid var(--border-color, #E0E0E0); border-radius: 6px; }
+    .pub-hint { font-size: 0.8rem; color: var(--secondary-color, #666); margin: 0 0 1.25rem; }
+
+    .pub-threads { list-style: none; padding: 0; margin: 0 0 1.5rem;
+        display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 0.5rem 1.5rem; }
+    .pub-threads li { font-size: 0.85rem; line-height: 1.4; color: var(--text-color, #333); }
+    .pub-threads strong { font-family: "JetBrains Mono", monospace; font-size: 0.8rem; }
+
+    .pub-controls { display: flex; flex-direction: column; gap: 0.6rem; margin: 1.5rem 0 1.25rem; }
+    .pub-row { display: flex; flex-wrap: wrap; gap: 0.4rem; align-items: center; }
+    .pub-row-label { font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.04em;
+        color: var(--secondary-color, #666); margin-right: 0.2rem; min-width: 3.5rem; }
+    .pub-btn { font-family: "JetBrains Mono", monospace; font-size: 0.78rem;
+        padding: 0.25rem 0.7rem; border: 1px solid var(--border-color, #E0E0E0);
+        border-radius: 999px; background: none; color: var(--secondary-color, #666); cursor: pointer; }
+    .pub-btn.active { background: var(--primary-color, #A43830); border-color: var(--primary-color, #A43830); color: #fff; }
+    .pub-chip { display: inline-flex; align-items: center; gap: 0.35rem; }
+    .pub-chip .pub-dot { width: 0.55rem; height: 0.55rem; }
+    .pub-chip.active { color: #fff; }
+
     .pub-list { display: flex; flex-direction: column; gap: 1.25rem; }
-    .pub-card {
-        border-left: 3px solid var(--border-color, #E0E0E0);
-        padding: 0.4rem 0 0.4rem 1rem;
-        scroll-margin-top: 5rem;
-        transition: background 0.3s ease;
-    }
+    .pub-card { border-left: 3px solid var(--border-color, #E0E0E0); padding: 0.4rem 0 0.4rem 1rem;
+        scroll-margin-top: 5rem; transition: background 0.3s ease; }
     .pub-card.flash { background: rgba(164, 56, 48, 0.08); }
     .pub-card-title { margin: 0 0 0.3rem; font-size: 1.02rem; line-height: 1.35; }
     .pub-card-title a { color: var(--text-color, #333) !important; background: none !important; }
     .pub-card-title a:hover { color: var(--primary-color, #A43830) !important; }
-    .pub-meta {
-        font-size: 0.82rem;
-        color: var(--secondary-color, #666);
-        margin-bottom: 0.4rem;
-        line-height: 1.4;
-    }
+    .pub-meta { font-size: 0.82rem; color: var(--secondary-color, #666); margin-bottom: 0.4rem; line-height: 1.4; }
     .pub-authors { font-style: italic; }
     .pub-tags { display: inline-flex; flex-wrap: wrap; gap: 0.4rem; vertical-align: middle; }
-    .pub-topic {
-        display: inline-flex; align-items: center; gap: 0.35rem;
-        font-family: "JetBrains Mono", monospace; font-size: 0.72rem;
-    }
+    .pub-topic { display: inline-flex; align-items: center; gap: 0.35rem;
+        font-family: "JetBrains Mono", monospace; font-size: 0.72rem; }
     .pub-dot { width: 0.6rem; height: 0.6rem; border-radius: 50%; display: inline-block; }
-    .pub-role {
-        font-family: "JetBrains Mono", monospace; font-size: 0.68rem;
-        text-transform: uppercase; letter-spacing: 0.03em;
-        padding: 0.05rem 0.4rem; border-radius: 3px;
+    .pub-type { font-family: "JetBrains Mono", monospace; font-size: 0.68rem; text-transform: uppercase;
+        letter-spacing: 0.03em; padding: 0.05rem 0.4rem; border-radius: 3px;
         background: var(--light-bg, #FAFAFA); color: var(--secondary-color, #666);
-        border: 1px solid var(--border-color, #E0E0E0);
-    }
-    .pub-abstract {
-        font-size: 0.9rem; line-height: 1.5; color: var(--text-color, #333);
-        display: -webkit-box; -webkit-line-clamp: 3; -webkit-box-orient: vertical;
-        overflow: hidden;
-    }
+        border: 1px solid var(--border-color, #E0E0E0); }
+    .pub-abstract { font-size: 0.9rem; line-height: 1.5; color: var(--text-color, #333);
+        display: -webkit-box; -webkit-line-clamp: 3; -webkit-box-orient: vertical; overflow: hidden; }
     .pub-abstract.open { -webkit-line-clamp: unset; }
-    .pub-more {
-        font-family: "JetBrains Mono", monospace; font-size: 0.75rem;
-        background: none; border: none; padding: 0.2rem 0; cursor: pointer;
-        color: var(--primary-color, #A43830);
-    }
+    .pub-more { font-family: "JetBrains Mono", monospace; font-size: 0.75rem; background: none;
+        border: none; padding: 0.2rem 0; cursor: pointer; color: var(--primary-color, #A43830); }
 </style>
 
 <div id="pub-landscape" class="pub-landscape"></div>
-<p class="pub-hint">each point is a paper · colour = research thread · hover to peek · click to jump · use the legend to toggle threads</p>
+<p class="pub-hint">each paper sits on the research thread(s) it belongs to — papers shared by two threads sit between them, linked to both · hover to peek · click to jump · use the legend to toggle threads</p>
 
-<div class="pub-filters">
-    <button class="pub-filter active" data-role="all">all</button>
-    <button class="pub-filter" data-role="corresponding">corresponding author</button>
-    <button class="pub-filter" data-role="first">first author</button>
-    <button class="pub-filter" data-role="coauthor">coauthor</button>
+<ul class="pub-threads">
+    {{- range $data.threads }}
+    <li><span class="pub-dot" style="background:{{ .color }}"></span> <strong>{{ .name }}</strong> — {{ .description }}</li>
+    {{- end }}
+</ul>
+
+<div class="pub-controls">
+    <div class="pub-row">
+        <span class="pub-row-label">type</span>
+        <button class="pub-btn active" data-filter-type="all">all</button>
+        <button class="pub-btn" data-filter-type="peer-reviewed">peer-reviewed</button>
+        <button class="pub-btn" data-filter-type="preprint">preprints</button>
+        <button class="pub-btn" data-filter-type="editorial">editorials &amp; comments</button>
+    </div>
+    <div class="pub-row">
+        <span class="pub-row-label">thread</span>
+        <button class="pub-btn active" data-filter-pillar="all">all</button>
+        {{- range $data.threads }}
+        <button class="pub-btn pub-chip" data-filter-pillar="{{ .name }}" data-color="{{ .color }}"><span class="pub-dot" style="background:{{ .color }}"></span>{{ .name }}</button>
+        {{- end }}
+    </div>
 </div>
 
 <div class="pub-list">
     {{- range $data.papers -}}
     {{- $id := printf "pub-%s" (replaceRE "[^a-zA-Z0-9]+" "-" .doi) -}}
-    {{- $topic := index (where $data.topics "id" .topic) 0 -}}
-    <div class="pub-card" id="{{ $id }}" data-role="{{ .role | default "" }}">
+    <div class="pub-card" id="{{ $id }}" data-type="{{ .type }}" data-pillars="{{ delimit .pillars " " }}">
         <h3 class="pub-card-title">
             <a href="{{ .url }}" target="_blank" rel="noopener">{{ .title }}</a>
         </h3>
@@ -100,8 +82,8 @@
             <span class="pub-authors">{{ delimit (first 8 .authors) ", " }}{{ if gt (len .authors) 8 }}, et al.{{ end }}</span><br>
             {{ with .venue }}{{ . }} · {{ end }}{{ .year }}{{ if .citations }}{{ if gt .citations 0.0 }} · {{ .citations }} citations{{ end }}{{ end }}
             &nbsp; <span class="pub-tags">
-                {{ with $topic }}<span class="pub-topic"><span class="pub-dot" style="background:{{ .color }}"></span>{{ .name }}</span>{{ end }}
-                {{ with .role }}<span class="pub-role">{{ . }}</span>{{ end }}
+                {{- range .pillars }}{{ $t := index (where $data.threads "name" .) 0 }}{{ with $t }}<span class="pub-topic"><span class="pub-dot" style="background:{{ .color }}"></span>{{ .name }}</span>{{ end }}{{ end }}
+                {{ if ne .type "peer-reviewed" }}<span class="pub-type">{{ .type }}</span>{{ end }}
             </span>
         </div>
         {{ with .abstract }}
@@ -117,63 +99,113 @@
 (function () {
     var DATA = JSON.parse({{ $data | jsonify }});
     var idOf = function (doi) { return "pub-" + doi.replace(/[^a-zA-Z0-9]+/g, "-"); };
+    var threads = DATA.threads, n = threads.length;
 
-    // one Plotly trace per research thread (pillar)
-    var traces = DATA.topics.map(function (t) {
-        var pts = DATA.papers.filter(function (p) { return p.topic === t.id; });
+    // place each thread on a circle; papers sit at the mean of their threads' anchors
+    var anchors = {};
+    threads.forEach(function (t, i) {
+        var a = -Math.PI / 2 + (i / n) * 2 * Math.PI;
+        anchors[t.name] = { x: Math.cos(a), y: Math.sin(a) };
+    });
+    var hash = function (s) {
+        var h = 2166136261;
+        for (var i = 0; i < s.length; i++) { h ^= s.charCodeAt(i); h = Math.imul(h, 16777619); }
+        return h >>> 0;
+    };
+    DATA.papers.forEach(function (p) {
+        var ps = (p.pillars || []).filter(function (x) { return anchors[x]; });
+        if (!ps.length) ps = [threads[0].name];
+        var cx = 0, cy = 0;
+        ps.forEach(function (x) { cx += anchors[x].x; cy += anchors[x].y; });
+        cx /= ps.length; cy /= ps.length;
+        var h = hash(p.doi), ang = (h % 628) / 100, rad = 0.10 + ((h >>> 9) % 100) / 100 * 0.16;
+        p._x = cx + rad * Math.cos(ang); p._y = cy + rad * Math.sin(ang); p._ps = ps;
+    });
+
+    // faint links from a shared paper to each of its threads
+    var lx = [], ly = [];
+    DATA.papers.forEach(function (p) {
+        if (p._ps.length > 1) p._ps.forEach(function (x) {
+            lx.push(p._x, anchors[x].x, null); ly.push(p._y, anchors[x].y, null);
+        });
+    });
+    var linkTrace = { x: lx, y: ly, mode: "lines", type: "scatter", hoverinfo: "skip",
+        showlegend: false, line: { color: "rgba(120,120,120,0.28)", width: 1 } };
+
+    // soft halo disc at each thread anchor
+    var anchorTrace = {
+        x: threads.map(function (t) { return anchors[t.name].x; }),
+        y: threads.map(function (t) { return anchors[t.name].y; }),
+        mode: "markers", type: "scatter", hoverinfo: "skip", showlegend: false,
+        marker: { size: 48, color: threads.map(function (t) { return t.color; }), opacity: 0.12 }
+    };
+
+    // one point trace per thread (coloured by the paper's primary thread)
+    var pointTraces = threads.map(function (t) {
+        var pts = DATA.papers.filter(function (p) { return p._ps[0] === t.name; });
         return {
             name: t.name,
-            x: pts.map(function (p) { return p.x; }),
-            y: pts.map(function (p) { return p.y; }),
-            customdata: pts.map(function (p) {
-                return [p.title, p.venue || "", p.year, idOf(p.doi)];
-            }),
-            mode: "markers",
-            type: "scatter",
-            marker: {
-                color: t.color,
-                size: 11,
-                line: { width: 1, color: "rgba(255,255,255,0.8)" },
-                opacity: 0.9
-            },
+            x: pts.map(function (p) { return p._x; }),
+            y: pts.map(function (p) { return p._y; }),
+            customdata: pts.map(function (p) { return [p.title, p.venue || "", p.year, idOf(p.doi)]; }),
+            mode: "markers", type: "scatter",
+            marker: { color: t.color, size: 11, line: { width: 1, color: "rgba(255,255,255,0.85)" }, opacity: 0.95 },
             hovertemplate: "<b>%{customdata[0]}</b><br>%{customdata[1]} · %{customdata[2]}<extra></extra>"
         };
     });
 
-    var hidden = { showgrid: false, zeroline: false, showticklabels: false, title: "" };
+    var hidden = { showgrid: false, zeroline: false, showticklabels: false, title: "", range: [-1.6, 1.6] };
     var layout = {
-        hovermode: "closest",
-        dragmode: "pan",
-        margin: { l: 10, r: 10, t: 10, b: 10 },
-        xaxis: hidden, yaxis: hidden,
-        legend: { orientation: "h", y: -0.02, font: { size: 11 } },
-        paper_bgcolor: "rgba(0,0,0,0)",
-        plot_bgcolor: "rgba(0,0,0,0)",
-        hoverlabel: { align: "left", bgcolor: "#fff", bordercolor: "#A43830" }
+        hovermode: "closest", dragmode: "pan", margin: { l: 10, r: 10, t: 10, b: 10 },
+        xaxis: hidden,
+        yaxis: { showgrid: false, zeroline: false, showticklabels: false, title: "",
+                 range: [-1.6, 1.6], scaleanchor: "x", scaleratio: 1 },
+        legend: { orientation: "h", y: -0.03, font: { size: 11 } },
+        paper_bgcolor: "rgba(0,0,0,0)", plot_bgcolor: "rgba(0,0,0,0)",
+        hoverlabel: { align: "left", bgcolor: "#fff", bordercolor: "#A43830" },
+        annotations: threads.map(function (t) {
+            var a = anchors[t.name];
+            return { x: a.x * 1.32, y: a.y * 1.32, text: t.name, showarrow: false,
+                     font: { size: 13, color: t.color }, xanchor: "center", yanchor: "middle" };
+        })
     };
 
     var el = document.getElementById("pub-landscape");
-    Plotly.newPlot(el, traces, layout, { responsive: true, displayModeBar: false }).then(function () {
+    Plotly.newPlot(el, [linkTrace, anchorTrace].concat(pointTraces), layout,
+                   { responsive: true, displayModeBar: false }).then(function () {
         el.on("plotly_click", function (ev) {
-            var id = ev.points[0].customdata[3];
-            var card = document.getElementById(id);
-            if (!card) return;
+            var cd = ev.points[0].customdata; if (!cd) return;
+            var card = document.getElementById(cd[3]); if (!card) return;
             card.scrollIntoView({ behavior: "smooth", block: "center" });
             card.classList.add("flash");
             setTimeout(function () { card.classList.remove("flash"); }, 1500);
         });
     });
 
-    // role filter for the card list
-    document.querySelectorAll(".pub-filter").forEach(function (btn) {
-        btn.addEventListener("click", function () {
-            document.querySelectorAll(".pub-filter").forEach(function (b) { b.classList.remove("active"); });
-            btn.classList.add("active");
-            var role = btn.dataset.role;
-            document.querySelectorAll(".pub-card").forEach(function (card) {
-                card.style.display = (role === "all" || card.dataset.role === role) ? "" : "none";
+    // list filters: publication type AND research thread
+    var curType = "all", curPillar = "all";
+    var apply = function () {
+        document.querySelectorAll(".pub-card").forEach(function (c) {
+            var typeOk = curType === "all" || c.dataset.type === curType;
+            var pills = (c.dataset.pillars || "").split(" ");
+            var pillOk = curPillar === "all" || pills.indexOf(curPillar) >= 0;
+            c.style.display = (typeOk && pillOk) ? "" : "none";
+        });
+    };
+    var wire = function (attr, set) {
+        document.querySelectorAll("[" + attr + "]").forEach(function (b) {
+            b.addEventListener("click", function () {
+                document.querySelectorAll("[" + attr + "]").forEach(function (x) {
+                    x.classList.remove("active");
+                    if (x.dataset.color) x.style.background = x.style.borderColor = x.style.color = "";
+                });
+                b.classList.add("active");
+                if (b.dataset.color) { b.style.background = b.dataset.color; b.style.borderColor = b.dataset.color; b.style.color = "#fff"; }
+                set(b); apply();
             });
         });
-    });
+    };
+    wire("data-filter-type", function (b) { curType = b.dataset.filterType; });
+    wire("data-filter-pillar", function (b) { curPillar = b.dataset.filterPillar; });
 }());
 </script>

--- a/publications/build.py
+++ b/publications/build.py
@@ -1,17 +1,14 @@
 #!/usr/bin/env python3
 """Build data/publications.json for the lamalab.org publications page.
 
-Pipeline:  dois.txt -> metadata + abstracts (CrossRef / Semantic Scholar)
-           -> abstract embeddings -> 2D projection -> topic clusters + labels
-           -> data/publications.json  (committed; rendered by Hugo, never recomputed
-              at build time).
+Pipeline:  dois.txt -> metadata + abstracts (CrossRef / Semantic Scholar / arXiv)
+           -> classify each paper into one or two research threads (pillars)
+           -> data/publications.json  (committed; rendered by Hugo as a pillar map
+              + filterable list, never recomputed at build time).
 
-The backends degrade gracefully so the script runs anywhere:
-  * embeddings: a hosted model over HTTPS (OPENAI_API_KEY -> text-embedding-3-large,
-                or VOYAGE_API_KEY -> voyage-3.5; no torch) -> local
-                sentence-transformers -> TF-IDF + TruncatedSVD
-  * pillars:    a strong LLM (ANTHROPIC_API_KEY) -> embedding similarity -> keywords
-  * 2D layout:  UMAP if installed, else PCA
+Classification degrades gracefully: a strong LLM reads the abstract
+(ANTHROPIC_API_KEY) -> keyword heuristic. An explicit pillar in dois.txt always
+wins. The figure is anchored on the pillars (no embeddings needed).
 
 Human review = edit data/publications.json directly. Re-runs preserve human-renamed
 topics by matching each new cluster to the prior topic with the most DOIs in common.
@@ -31,7 +28,6 @@ import sys
 import time
 from pathlib import Path
 
-import numpy as np
 import requests
 
 HERE = Path(__file__).resolve().parent
@@ -71,7 +67,7 @@ def _parse_annotations(comment: str) -> dict:
     """Parse the `{...}` block of a dois.txt comment. Supports bare flags
     (a role, a pillar, or `highlight`) and `key=value` pairs (`venue=NeurIPS 2025`,
     `pillar=evaluation`). Comma-separated so values may contain spaces."""
-    ann = {"role": None, "highlight": False, "pillar": None, "venue": None}
+    ann = {"role": None, "highlight": False, "pillars": [], "venue": None, "type": None}
     m = re.search(r"\{([^}]*)\}", comment)
     if not m:
         return ann
@@ -82,16 +78,25 @@ def _parse_annotations(comment: str) -> dict:
         if "=" in tok:
             key, _, val = tok.partition("=")
             key, val = key.strip().lower(), val.strip()
-            if key in ann:
-                ann[key] = val.lower() if key in ("role", "pillar") else val
+            if key == "pillar":
+                ann["pillars"].append(val.lower())
+            elif key in ann:
+                ann[key] = val.lower() if key in ("role", "type") else val
             continue
         low = tok.lower()
         if low in ("highlight", "highlighted"):
             ann["highlight"] = True
         elif low in ROLES:
             ann["role"] = low
-        elif low in PILLARS or low == "unclassified":
-            ann["pillar"] = low
+        elif low in PILLARS:
+            ann["pillars"].append(low)
+        elif low in ("community", "unclassified"):     # old alias maps to community
+            ann["pillars"].append("community")
+    seen: list[str] = []
+    for p in ann["pillars"]:
+        if p not in seen:
+            seen.append(p)
+    ann["pillars"] = seen[:2]
     return ann
 
 
@@ -273,92 +278,27 @@ def fetch(entry: dict, force: bool) -> dict | None:
 
 
 # --------------------------------------------------------------------------- #
-# embeddings + 2D projection
+# classification into the group's research threads (pillars)
 # --------------------------------------------------------------------------- #
-def _api_embed(texts: list[str]) -> np.ndarray | None:
-    """Embed via a hosted model over plain HTTPS — no torch. Prefers OpenAI
-    (`text-embedding-3-large`), then Voyage. Returns None if no key is set."""
-    texts = [t[:8000] for t in texts]                      # stay under token limits
-    if os.environ.get("OPENAI_API_KEY"):
-        key = os.environ["OPENAI_API_KEY"]
-        model = os.environ.get("PUBLICATIONS_EMBED_MODEL", "text-embedding-3-large")
-        url, payload, prov = ("https://api.openai.com/v1/embeddings",
-                              {"model": model, "input": texts}, "OpenAI")
-    elif os.environ.get("VOYAGE_API_KEY"):
-        key = os.environ["VOYAGE_API_KEY"]
-        model = os.environ.get("PUBLICATIONS_EMBED_MODEL", "voyage-3.5")
-        url, payload, prov = ("https://api.voyageai.com/v1/embeddings",
-                              {"model": model, "input": texts, "input_type": "document"}, "Voyage")
-    else:
-        return None
-    try:
-        from sklearn.preprocessing import normalize
-        r = requests.post(url, headers={"Authorization": f"Bearer {key}"},
-                          json=payload, timeout=120)
-        r.raise_for_status()
-        rows = sorted(r.json()["data"], key=lambda d: d.get("index", 0))
-        print(f"  embeddings: {prov} {model}")
-        return normalize(np.asarray([d["embedding"] for d in rows], dtype=float))
-    except Exception as e:                                  # noqa: BLE001
-        print(f"  embeddings: {prov} API failed ({e.__class__.__name__}), falling back",
-              file=sys.stderr)
-        return None
-
-
-def embed(texts: list[str]) -> np.ndarray:
-    """Dense embeddings. Preference: hosted model (OpenAI/Voyage, no torch) →
-    local sentence-transformers → TF-IDF + SVD."""
-    api = _api_embed(texts)
-    if api is not None:
-        return api
-    try:
-        from sentence_transformers import SentenceTransformer
-        model = SentenceTransformer("all-MiniLM-L6-v2")
-        print("  embeddings: sentence-transformers/all-MiniLM-L6-v2")
-        return np.asarray(model.encode(texts, normalize_embeddings=True))
-    except Exception as e:                                  # noqa: BLE001
-        print(f"  embeddings: TF-IDF fallback ({e.__class__.__name__})")
-        from sklearn.decomposition import TruncatedSVD
-        from sklearn.feature_extraction.text import TfidfVectorizer
-        from sklearn.preprocessing import normalize
-        tfidf = TfidfVectorizer(stop_words="english", max_features=4096,
-                                ngram_range=(1, 2)).fit_transform(texts)
-        dim = max(2, min(50, tfidf.shape[1] - 1, len(texts) - 1))
-        with np.errstate(divide="ignore", over="ignore", invalid="ignore"):
-            svd = TruncatedSVD(n_components=dim, random_state=42)
-            reduced = np.nan_to_num(svd.fit_transform(tfidf))
-        return normalize(reduced)
-
-
-def project_2d(emb: np.ndarray) -> np.ndarray:
-    n = len(emb)
-    if n < 3:                                               # too few for any reducer
-        coords = np.zeros((n, 2))
-        for i in range(n):
-            coords[i] = [i, 0]
-        return coords
-    try:
-        import umap
-        reducer = umap.UMAP(n_components=2, n_neighbors=min(15, n - 1),
-                            min_dist=0.1, metric="cosine", random_state=42)
-        print("  layout: UMAP")
-        return reducer.fit_transform(emb)
-    except Exception as e:                                  # noqa: BLE001
-        print(f"  layout: PCA fallback ({e.__class__.__name__})")
-        from sklearn.decomposition import PCA
-        return PCA(n_components=2, random_state=42).fit_transform(emb)
-
-
-# --------------------------------------------------------------------------- #
-# classification into the group's four research threads (pillars)
-# --------------------------------------------------------------------------- #
-PILLAR_ORDER = PILLARS + ["unclassified"]
+PILLAR_ORDER = PILLARS + ["community"]
 PILLAR_COLOR = {
     "perception": "#2C6E91",   # blue
     "reasoning": "#8E5BA6",    # purple
     "evaluation": "#A43830",   # brand burgundy
     "action": "#5B8C5A",       # green
-    "unclassified": "#9AA0A6", # grey
+    "community": "#C98A3C",    # amber — perspectives, education, community-building
+}
+# one-line blurbs shown as a legend on the page
+PILLAR_BLURB = {
+    "perception": "understanding chemistry from what we actually measure — spectra and "
+                  "characterization data, and the knowledge buried in the literature.",
+    "reasoning": "combining formal rules with the tacit heuristics expert chemists use, "
+                 "so models reason rather than pattern-match.",
+    "evaluation": "honestly measuring what models and agents can really do — and where "
+                  "they only look capable.",
+    "action": "predictions experimentalists can act on, starting from the recipes and "
+              "processing conditions they control.",
+    "community": "perspectives, education, and community-building around AI for chemistry.",
 }
 # short descriptions (for embedding-based auto-suggestion) and keyword fallbacks
 PILLAR_DESC = {
@@ -390,17 +330,25 @@ PILLAR_KEYWORDS = {
 }
 
 
-def _keyword_pillar(text: str) -> str:
+def _keyword_pillars(text: str) -> list[str]:
     t = f" {text.lower()} "
     scores = {p: sum(t.count(k) for k in kws) for p, kws in PILLAR_KEYWORDS.items()}
     best = max(scores, key=scores.get)
-    return best if scores[best] > 0 else "unclassified"
+    return [best] if scores[best] > 0 else ["community"]
 
 
-def _llm_classify(papers: list[dict]) -> list[str] | None:
-    """Classify papers into pillars with a strong LLM (Claude), reading the full
-    abstract against the pillar descriptions. Returns None if the SDK or an API
-    key is unavailable, so the caller can fall back."""
+def _dedupe(seq: list[str]) -> list[str]:
+    out: list[str] = []
+    for x in seq:
+        if x in PILLAR_ORDER and x not in out:
+            out.append(x)
+    return out[:2]
+
+
+def _llm_classify(papers: list[dict]) -> list[list[str]] | None:
+    """Ask a strong LLM (Claude) to read each abstract and assign one or two
+    research threads. Returns a list of 1–2 pillar names per paper, or None if no
+    key/SDK is available (so the caller can fall back)."""
     if not (os.environ.get("ANTHROPIC_API_KEY") or os.environ.get("ANTHROPIC_AUTH_TOKEN")):
         return None
     try:
@@ -411,74 +359,48 @@ def _llm_classify(papers: list[dict]) -> list[str] | None:
     pillar_block = "\n".join(f"- {p}: {PILLAR_DESC[p]}" for p in PILLARS)
     items = [{"i": i, "title": p["title"], "abstract": (p.get("abstract") or "")[:3000]}
              for i, p in enumerate(papers)]
-    schema = {
-        "type": "object",
-        "properties": {
-            "classifications": {
-                "type": "array",
-                "items": {
-                    "type": "object",
-                    "properties": {
-                        "i": {"type": "integer"},
-                        "pillar": {"type": "string", "enum": PILLAR_ORDER},
-                    },
-                    "required": ["i", "pillar"],
-                    "additionalProperties": False,
-                },
-            }
-        },
-        "required": ["classifications"],
-        "additionalProperties": False,
-    }
-    system = (
-        "You classify scientific papers into a research group's four pillars. "
-        "Read each paper's title and abstract and assign the single best-fitting "
-        "pillar. Use 'unclassified' only when a paper (e.g. an editorial or "
-        "community note) genuinely fits none. Return every paper exactly once."
-    )
-    user = (f"The four pillars:\n{pillar_block}\n\n"
-            f"Classify these papers by their index `i`:\n{json.dumps(items, ensure_ascii=False)}")
+    prompt = (
+        "You assign scientific papers to a research group's threads. The four "
+        f"research threads:\n{pillar_block}\n- community: non-research outputs "
+        "(editorials, comments, education, perspectives).\n\n"
+        "For each paper below, pick the ONE or TWO threads that genuinely fit "
+        "(prefer one; use two only when a paper substantively spans both). Use "
+        "'community' only for non-research outputs, and then alone.\n\n"
+        f"Papers:\n{json.dumps(items, ensure_ascii=False)}\n\n"
+        "Respond with ONLY a JSON array, no prose, each element "
+        '{"i": <index>, "pillars": ["<thread>", ...]} using these exact names: '
+        f"{PILLAR_ORDER}.")
     try:
         resp = anthropic.Anthropic().messages.create(
-            model=model, max_tokens=8000, system=system,
-            messages=[{"role": "user", "content": user}],
-            output_config={"format": {"type": "json_schema", "schema": schema}})
+            model=model, max_tokens=4000,
+            messages=[{"role": "user", "content": prompt}])
         text = next(b.text for b in resp.content if b.type == "text")
-        by_i = {c["i"]: c["pillar"] for c in json.loads(text)["classifications"]}
+        arr = json.loads(re.search(r"\[.*\]", text, re.S).group(0))
+        by_i = {d["i"]: _dedupe(d.get("pillars", [])) for d in arr}
         print(f"  pillars: LLM classification ({model})")
-        return [by_i.get(i, "unclassified") for i in range(len(papers))]
+        return [by_i.get(i) or ["community"] for i in range(len(papers))]
     except Exception as e:                                 # noqa: BLE001
         print(f"  pillars: LLM failed ({e.__class__.__name__}), falling back", file=sys.stderr)
         return None
 
 
-def suggest_pillars(papers: list[dict], texts: list[str]) -> list[str]:
-    """Auto-suggest a pillar per paper. Preference order: a strong LLM reading the
-    abstract → transformer similarity to the pillar descriptions → keyword heuristic."""
+def suggest_pillars(papers: list[dict], texts: list[str]) -> list[list[str]]:
+    """Auto-suggest 1–2 pillars per paper: a strong LLM reading the abstract,
+    else a keyword heuristic."""
     llm = _llm_classify(papers)
     if llm is not None:
         return llm
-    try:
-        from sentence_transformers import SentenceTransformer
-        model = SentenceTransformer("all-MiniLM-L6-v2")
-        pe = model.encode([PILLAR_DESC[p] for p in PILLARS], normalize_embeddings=True)
-        te = model.encode(texts, normalize_embeddings=True)
-        sims = np.asarray(te) @ np.asarray(pe).T
-        print("  pillars: embedding similarity (sentence-transformers)")
-        return [PILLARS[i] for i in sims.argmax(1)]
-    except Exception:                                      # noqa: BLE001
-        print("  pillars: keyword heuristic")
-        return [_keyword_pillar(t) for t in texts]
+    print("  pillars: keyword heuristic")
+    return [_keyword_pillars(t) for t in texts]
 
 
 def classify_pillars(papers: list[dict], texts: list[str]) -> None:
-    """Fill in a pillar for every paper: explicit annotation wins, otherwise
-    auto-suggest. Mutates papers in place."""
-    need = [i for i, p in enumerate(papers) if not p.get("pillar")]
+    """Fill in pillars for papers lacking an explicit annotation. Mutates in place."""
+    need = [i for i, p in enumerate(papers) if not p.get("pillars")]
     if need:
         suggestions = suggest_pillars([papers[i] for i in need], [texts[i] for i in need])
-        for idx, pil in zip(need, suggestions):
-            papers[idx]["pillar"] = pil
+        for idx, pillars in zip(need, suggestions):
+            papers[idx]["pillars"] = pillars or ["community"]
             papers[idx]["pillar_auto"] = True              # flag for human review
 
 
@@ -501,40 +423,33 @@ def main() -> None:
     for entry in entries:
         rec = fetch(entry, args.force)
         if rec:
-            rec["role"] = entry["role"]
             rec["highlighted"] = entry["highlight"]
-            rec["pillar"] = entry["pillar"]                 # explicit annotation (may be None)
+            rec["pillars"] = entry["pillars"] or None       # explicit annotation, else LLM fills
+            is_arxiv = rec["doi"].lower().startswith("10.48550/arxiv")
+            rec["type"] = entry["type"] or ("preprint" if is_arxiv else "peer-reviewed")
             print(f"  ✓ {rec['year']}  {rec['title'][:70]}")
             papers.append(rec)
     if not papers:
         sys.exit("no papers resolved — check the DOIs")
 
     texts = [f"{p['title']}. {p.get('abstract', '')}".strip() for p in papers]
-    print("embedding abstracts ...")
-    emb = embed(texts)
-    coords = project_2d(emb)
-
     print("classifying into research threads ...")
-    classify_pillars(papers, texts)                        # fills any missing pillar
+    classify_pillars(papers, texts)                        # fills any missing pillars
 
-    # the four pillars are the landscape's topics — fixed colours, canonical order
-    present = [p for p in PILLAR_ORDER if any(pp["pillar"] == p for pp in papers)]
-    pid = {name: PILLAR_ORDER.index(name) for name in PILLAR_ORDER}
-    topics = [{"id": pid[name], "name": name, "color": PILLAR_COLOR[name]}
-              for name in present]
-
-    for p, (x, y) in zip(papers, coords):
-        p["topic"] = pid[p["pillar"]]
-        p["x"] = round(float(x), 4)
-        p["y"] = round(float(y), 4)
+    # threads are the group's pillars — canonical order, fixed colours + blurbs
+    present = [name for name in PILLAR_ORDER
+               if any(name in p["pillars"] for p in papers)]
+    threads = [{"id": PILLAR_ORDER.index(name), "name": name,
+                "color": PILLAR_COLOR[name], "description": PILLAR_BLURB[name]}
+               for name in present]
 
     papers.sort(key=lambda p: (-(p["year"] or 0), p["title"].lower()))
 
     OUT_FILE.parent.mkdir(exist_ok=True)
-    OUT_FILE.write_text(json.dumps({"topics": topics, "papers": papers},
+    OUT_FILE.write_text(json.dumps({"threads": threads, "papers": papers},
                                    indent=2, ensure_ascii=False) + "\n")
     print(f"\nwrote {OUT_FILE.relative_to(REPO)}: "
-          f"{len(papers)} papers across {len(topics)} threads")
+          f"{len(papers)} papers across {len(threads)} threads")
 
 
 if __name__ == "__main__":

--- a/publications/dois.txt
+++ b/publications/dois.txt
@@ -1,70 +1,64 @@
 # Curated DOI list for the lamalab publications page.
 #
 # One entry per line: a DOI or `arXiv:<id>`, plus an optional `# comment` whose
-# {…} block carries curated annotations that flow into the page:
-#     {perception|reasoning|evaluation|action|unclassified}   research thread (the plot colour)
-#     {corresponding|first|coauthor}                          author role (mirrors the group CV)
-#     {venue=NeurIPS 2025}                                    show a conference/journal venue
-# e.g.  10.1038/s41557-025-01815-x   # ChemBench {evaluation, corresponding}
+# {…} block carries curated annotations:
+#     {perception|reasoning|evaluation|action|community}   research thread(s) — up to two
+#     {type=peer-reviewed|preprint|editorial}              publication type (else inferred)
+#     {venue=NeurIPS 2025}                                 show a conference/journal venue
 #
-# The four threads are the group's research pillars — perception, reasoning,
-# evaluation, action. If a line has NO pillar annotation, build.py auto-classifies
-# it (a strong LLM reads the abstract against the pillar descriptions; the GitHub
-# Action provides the API key). An explicit pillar always wins, so this file stays
-# the human-reviewed source of truth.
+# Threads are the group's research pillars. If a line has NO thread annotation,
+# build.py asks a strong LLM to read the abstract and assign one or two threads
+# (the GitHub Action / a local .env provides ANTHROPIC_API_KEY). An explicit
+# annotation always wins, so this file stays the human-reviewed source of truth.
+# Type is inferred (arXiv -> preprint, else peer-reviewed) unless annotated.
 #
-# This list alone decides which papers appear — add/remove a line and re-run
-# `python build.py`. Scope: independent-PI era (2023+).
+# This list alone decides which papers appear. Scope: independent-PI era (2023+).
 
-# ── corresponding author ────────────────────────────────────────────────────
-10.1038/s41467-026-73846-y      # Elucidating structures from spectra {perception, corresponding}
-10.1021/acs.chemrev.5c00583     # General-purpose models for the chemical sciences {reasoning, corresponding}
-10.1038/s41524-025-01823-y      # PolyMetriX: digital polymer chemistry {action, corresponding}
-10.1016/j.commatsci.2025.114041 # Lessons from the trenches on evaluating ML systems {evaluation, corresponding}
-10.1038/s43588-025-00836-3      # Probing the limitations of multimodal language models {evaluation, corresponding}
-10.1038/s41557-025-01815-x      # A framework for evaluating chemical knowledge of LLMs (ChemBench) {evaluation, corresponding}
-10.1039/d4cs00913d              # From text to insight: LLMs for materials data extraction {perception, corresponding}
-10.1039/d3dd00113j              # 14 examples of how LLMs can transform materials science {reasoning, corresponding}
+# ── peer-reviewed ───────────────────────────────────────────────────────────
+10.1038/s41467-026-73846-y      # Elucidating structures from spectra
+10.1021/acs.chemrev.5c00583     # General-purpose models for the chemical sciences
+10.1038/s41524-025-01823-y      # PolyMetriX: digital polymer chemistry
+10.1016/j.commatsci.2025.114041 # Lessons from the trenches on evaluating ML systems
+10.1038/s43588-025-00836-3      # Probing the limitations of multimodal language models
+10.1038/s41557-025-01815-x      # A framework for evaluating chemical knowledge of LLMs (ChemBench)
+10.1039/d4cs00913d              # From text to insight: LLMs for materials data extraction
+10.1039/d3dd00113j              # 14 examples of how LLMs can transform materials science
+10.1039/d4sc04401k              # Assessment of fine-tuned LLMs for real-world chemistry
+10.1038/s42256-023-00788-1      # Leveraging LLMs for predictive chemistry
+10.1016/j.carbpol.2026.124890   # Predicting acetalated dextran nanoparticle features
+10.1039/d5dd00109a              # MOFChecker
+arXiv:2505.12534                # ChemPile: 250GB dataset for chemical foundation models {type=peer-reviewed, venue=NeurIPS 2025}
 
-# ── first author ────────────────────────────────────────────────────────────
-10.1039/d4sc04401k              # Assessment of fine-tuned LLMs for real-world chemistry {evaluation, first}
-10.1038/s42256-023-00788-1      # Leveraging LLMs for predictive chemistry {action, first}
-# 10.1021/acscentsci.2c01177      # An ecosystem for digital reticular chemistry {first}
-# 10.1126/sciadv.adc9576          # Machine learning for industrial processes (amine emissions) {action, first}
+# ── preprints ───────────────────────────────────────────────────────────────
+arXiv:2406.17295                # Less can be more for predicting properties with LLMs
+arXiv:2604.18805                # AI scientists produce results without reasoning scientifically
+arXiv:2602.17730                # Clever materials: good materials for the wrong reasons
+arXiv:2605.13826                # Reducing cross-sample prediction churn in scientific ML
+arXiv:2602.04696                # Beyond learning on molecules by weakly supervising on molecules
+arXiv:2601.21618                # Semantic content determines algorithmic performance
+arXiv:2601.17807                # An autonomous living database for perovskite photovoltaics
+arXiv:2605.08956                # Agentic AI scientists are not built for autonomous discovery
 
-# ── coauthor ────────────────────────────────────────────────────────────────
-10.1016/j.carbpol.2026.124890   # Predicting acetalated dextran nanoparticle features {action, coauthor}
-10.1039/d5dd00109a              # MOFChecker {action, coauthor}
-# 10.1021/acsmaterialsau.4c00139  # Non-uniform chiralization of metal-organic frameworks {coauthor}
-10.1016/j.chempr.2024.10.010    # Chemical education in digital chemistry {unclassified, coauthor}
-# 10.1039/d4dd00116h              # Deep learning-based recommendation system for MOFs {coauthor}
-# 10.1038/s41586-024-07683-8      # A holistic platform for accelerating sorbent-based carbon capture {coauthor}
-10.1021/acscentsci.3c00500      # Prioritizing mentorship as scientific leaders {unclassified, coauthor}
-# 10.1039/d3dd00079f              # Biomass to energy: ML model for optimum gasification {coauthor}
-# 10.1002/adfm.202301594          # DFT-based discovery of COF photocatalysts {coauthor}
-
-# ── community / perspectives ────────────────────────────────────────────────
-10.1038/s43588-025-00871-0      # Vision language models excel at perception, struggle at reasoning {evaluation, corresponding}
-10.1038/s41557-025-01865-1      # Are large language models superhuman chemists? (briefing) {evaluation, corresponding}
-10.1038/s41570-025-00750-2      # Real AI advances require collaboration {unclassified, corresponding}
-10.1088/2632-2153/ae0d5d        # Perspective on AI for accelerated materials design (AI4Mat) {unclassified, coauthor}
-
-# ── preprints / conference papers ───────────────────────────────────────────
-arXiv:2505.12534                # ChemPile: 250GB dataset for chemical foundation models {reasoning, corresponding, venue=NeurIPS 2025}
-arXiv:2406.17295                # Less can be more for predicting properties with LLMs {action, corresponding}
-arXiv:2604.18805                # AI scientists produce results without reasoning scientifically {evaluation, corresponding}
-arXiv:2602.17730                # Clever materials: good materials for the wrong reasons {evaluation, corresponding}
-arXiv:2605.13826                # Reducing cross-sample prediction churn in scientific ML {evaluation, corresponding}
-arXiv:2602.04696                # Beyond learning on molecules by weakly supervising on molecules {reasoning, corresponding}
-arXiv:2601.21618                # Semantic content determines algorithmic performance {evaluation, corresponding}
-arXiv:2601.17807                # An autonomous living database for perovskite photovoltaics {perception, corresponding}
-arXiv:2605.08956                # Agentic AI scientists are not built for autonomous discovery {evaluation, coauthor}
+# ── editorials & comments ───────────────────────────────────────────────────
+10.1016/j.chempr.2024.10.010    # Chemical education in digital chemistry {type=editorial}
+10.1021/acscentsci.3c00500      # Prioritizing mentorship as scientific leaders {type=editorial}
+10.1038/s43588-025-00871-0      # Vision language models excel at perception, struggle at reasoning {type=editorial}
+10.1038/s41557-025-01865-1      # Are large language models superhuman chemists? (briefing) {type=editorial}
+10.1038/s41570-025-00750-2      # Real AI advances require collaboration {type=editorial}
+10.1088/2632-2153/ae0d5d        # Perspective on AI for accelerated materials design (AI4Mat) {type=editorial}
 
 # ── earlier work (pre-2023, before independent PI) — uncomment to include ────
-# 10.1038/s41557-022-00910-7    # Making the collective knowledge of chemistry machine-actionable {perception, first}
-# 10.1021/acs.jchemed.1c01101   # Making molecules vibrate: interactive IR spectroscopy teaching {unclassified, first}
-# 10.1038/s41557-021-00717-y    # Using collective knowledge to assign oxidation states {perception, first}
-# 10.1038/s41467-021-22437-0    # Bias-free multiobjective active learning for materials design {action, first}
-# 10.1039/d0sc05337f            # A data-driven perspective on the colours of MOFs {perception, first}
-# 10.1021/acs.chemrev.0c00004   # Big-data science in porous materials {reasoning, first}
-# 10.1021/acs.jctc.9b00586      # Applicability of tail corrections in molecular simulations {action, first}
+# 10.1038/s41557-022-00910-7    # Making the collective knowledge of chemistry machine-actionable
+# 10.1021/acs.jchemed.1c01101   # Making molecules vibrate: interactive IR spectroscopy teaching
+# 10.1038/s41557-021-00717-y    # Using collective knowledge to assign oxidation states
+# 10.1038/s41467-021-22437-0    # Bias-free multiobjective active learning for materials design
+# 10.1039/d0sc05337f            # A data-driven perspective on the colours of MOFs
+# 10.1021/acs.chemrev.0c00004   # Big-data science in porous materials
+# 10.1021/acs.jctc.9b00586      # Applicability of tail corrections in molecular simulations
+# 10.1021/acscentsci.2c01177    # An ecosystem for digital reticular chemistry
+# 10.1126/sciadv.adc9576        # Machine learning for industrial processes (amine emissions)
+# 10.1021/acsmaterialsau.4c00139 # Non-uniform chiralization of metal-organic frameworks
+# 10.1039/d4dd00116h            # Deep learning-based recommendation system for MOFs
+# 10.1038/s41586-024-07683-8    # A holistic platform for accelerating sorbent-based carbon capture
+# 10.1039/d3dd00079f            # Biomass to energy: ML model for optimum gasification
+# 10.1002/adfm.202301594        # DFT-based discovery of COF photocatalysts

--- a/publications/requirements.txt
+++ b/publications/requirements.txt
@@ -1,14 +1,6 @@
-# Dependencies for publications/build.py — intentionally light (no torch).
-requests
-numpy
-scikit-learn
-umap-learn          # 2D projection of the embeddings (PCA fallback if absent)
-anthropic           # LLM pillar classification (needs ANTHROPIC_API_KEY)
+# Dependencies for publications/build.py — intentionally tiny.
+requests            # metadata + abstracts from CrossRef / Semantic Scholar / arXiv
+anthropic           # LLM thread classification (needs ANTHROPIC_API_KEY)
 
-# Embeddings come from a hosted model over plain HTTPS (no SDK, no torch):
-#   OPENAI_API_KEY  -> text-embedding-3-large   (preferred)
-#   VOYAGE_API_KEY  -> voyage-3.5
-# If neither key is set, the script falls back to a local model and finally to
-# TF-IDF. The local fallback is heavy (pulls torch) and only for offline use —
-# install it yourself when needed, it is deliberately NOT in this list:
-#   pip install sentence-transformers
+# Classification falls back to a keyword heuristic if anthropic / the key is
+# absent. The figure is anchored on the pillars, so no embedding model is needed.


### PR DESCRIPTION
Builds on the merged publications page (#40). This reworks the figure and how papers are organised.

## The figure: pillar anchor map (replaces the embedding map)
The four research threads — **perception, reasoning, evaluation, action** — plus **community** are anchor points. Each paper sits on the thread(s) it belongs to; a paper that spans two threads sits *between* them, with faint links to both. Hover to peek, click a point to jump to its card.

This makes the embedding/UMAP/OpenAI stack unnecessary, so it's gone — the pipeline is now just metadata fetch + an LLM that assigns threads. Much lighter deps (`requests` + `anthropic` only).

## Multi-thread classification (LLM-proposed, human-reviewed)
`build.py` asks Claude (`claude-opus-4-8`) to read each abstract and assign **one or two** threads. An explicit annotation in `dois.txt` always wins. Current run: 8 of 27 papers span two threads (e.g. ChemBench → evaluation + reasoning, MaCBench → evaluation + perception).

## "community" instead of "unclassified"
The catch-all is now a real **community** thread (perspectives, education, community-building) with its own colour, and each thread has a one-line blurb shown as a legend.

## Filters, not author roles
Dropped the corresponding/first/coauthor grouping (it's a group page). The list now filters by:
- **type** — peer-reviewed / preprints / editorials & comments (inferred: arXiv → preprint; or annotated)
- **thread** — click a thread to show only its papers (multi-thread papers match any of theirs)

`dois.txt` is reorganised by type; arXiv preprints (incl. ChemPile as a NeurIPS paper) are included.

## Verification
- `python publications/build.py` → 27 papers, 5 threads, LLM multi-thread assignments; data has no coordinates (the figure places papers client-side from thread membership).
- `hugo` builds clean; `/publications` renders the pillar map, the thread legend, both filter rows, and 27 cards with thread chips + type tags. Verified the multi-pillar placement and click-to-card wiring.
- Only `ANTHROPIC_API_KEY` is needed now (add it as an Actions secret); without it, classification falls back to a keyword heuristic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Replace the embedding-based publications landscape with a pillar-anchored thread map and multi-thread classification, simplifying the build pipeline and enriching the publications page with thread legend and type/thread filters.

New Features:
- Introduce multi-thread (one or two pillars) classification for each paper, driven by an LLM with a keyword heuristic fallback.
- Add publication type tagging (peer-reviewed, preprint, editorial/comment) inferred from annotations and DOIs, and expose it on the publications list.
- Render a pillar-anchored map where papers are positioned from their thread memberships, including visual links for multi-thread papers and a thread legend with blurbs.
- Provide client-side filters on the publications list by publication type and by research thread.

Enhancements:
- Redefine the former catch-all 'unclassified' category as a dedicated 'community' research thread with its own colour and description.
- Simplify the publications build pipeline by removing all embedding, projection, and heavy ML dependencies, relying only on metadata fetch plus thread classification.
- Revise the publications shortcode layout and styling to support the new pillar map, legend, thread chips, and type tags.

Build:
- Trim publications build dependencies to only requests and anthropic, and update the GitHub workflow to require only ANTHROPIC_API_KEY for classification.

Documentation:
- Update the publications page copy to describe the pillar-anchored map, multi-thread placement, and new filtering options.