### PR TITLE
Publications: incidence-matrix figure, media links, stable threads, basic SEO

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
-baseURL = 'http://lamalab.org'
+baseURL = 'https://lamalab.org'
 languageCode = 'en-us'
 relativeURLs = true
 title = 'Lab for AI in Materials Science'
@@ -6,6 +6,7 @@ theme = "cactus"
 colortheme = "white"
 description = "we are a research group trying to teach computers how to design materials that work in the real world"
 enableEmoji = true
+enableRobotsTXT = true
 # Disable Google Analytics to avoid template errors
 googleAnalytics = ""
 

--- a/content/publications.md
+++ b/content/publications.md
@@ -1,5 +1,6 @@
 ---
 title: "publications"
+description: "Publications from the Lab for AI in Materials Science (group of Kevin Maik Jablonka, Friedrich Schiller University Jena) — peer-reviewed papers and preprints on machine learning, large language models, and foundation models for chemistry and materials science."
 ---
 
 a map of what we work on, organised around our four research threads —

--- a/data/publications.json
+++ b/data/publications.json
@@ -33,53 +33,6 @@
   ],
   "papers": [
     {
-      "doi": "10.48550/arXiv.2605.08956",
-      "url": "https://arxiv.org/abs/2605.08956",
-      "title": "Agentic AI Scientists Are Not Built For Autonomous Scientific Discovery",
-      "authors": [
-        "Harshit Bisht",
-        "Vinay Kumar",
-        "Kevin Maik Jablonka",
-        " Mausam",
-        "N. M. Anoop Krishnan"
-      ],
-      "venue": "arXiv",
-      "year": 2026,
-      "abstract": "A growing body of work pursues AI scientists capable of end-to-end autonomous scientific discovery. This position paper argues that although they already function as co-scientists, agentic AI scientists are not built for autonomous scientific discovery. We identify the following challenges in building and deploying autonomous AI scientists: (1) Problem selection is influenced by the McNamara fallacy; (2) Agents are built on large language models (LLMs) whose training corpora omit tacit procedural and failure knowledge of laboratory practice; (3) Preference optimisation during post-training compresses output diversity toward consensus; and (4) Most scientific benchmarks measure single-turn prediction accuracy and lack feedback from physical experiments back to the computational model. These challenges are not just questions of scale and scaffolding; they require revisiting fundamental design choices. To build truly autonomous AI scientists, we recommend the use of scientific simulations as verifiers for training, the design of persistent world models that represent the shifting objectives governing real investigations, the establishment of a centralized preregistration repository for all AI-generated hypotheses, and application driven by scientific need rather than tool affordance.",
-      "citations": null,
-      "highlighted": false,
-      "pillars": [
-        "evaluation"
-      ],
-      "type": "preprint",
-      "pillar_auto": true
-    },
-    {
-      "doi": "10.48550/arXiv.2604.18805",
-      "url": "https://arxiv.org/abs/2604.18805",
-      "title": "AI scientists produce results without reasoning scientifically",
-      "authors": [
-        "Martiño Ríos-García",
-        "Nawaf Alampara",
-        "Chandan Gupta",
-        "Indrajeet Mandal",
-        "Sajid Mannan",
-        "Ali Asghar Aghajani",
-        "N. M. Anoop Krishnan",
-        "Kevin Maik Jablonka"
-      ],
-      "venue": "arXiv",
-      "year": 2026,
-      "abstract": "Large language model (LLM)-based systems are increasingly deployed to conduct scientific research autonomously, yet whether their reasoning adheres to the epistemic norms that make scientific inquiry self-correcting is poorly understood. Here, we evaluate LLM-based scientific agents across eight domains, spanning workflow execution to hypothesis-driven inquiry, through more than 25,000 agent runs and two complementary lenses: (i) a systematic performance analysis that decomposes the contributions of the base model and the agent scaffold, and (ii) a behavioral analysis of the epistemological structure of agent reasoning. We observe that the base model is the primary determinant of both performance and behavior, accounting for 41.4% of explained variance versus 1.5% for the scaffold. Across all configurations, evidence is ignored in 68% of traces, refutation-driven belief revision occurs in 26%, and convergent multi-test evidence is rare. The same reasoning pattern appears whether the agent executes a computational workflow or conducts hypothesis-driven inquiry. They persist even when agents receive near-complete successful reasoning trajectories as context, and the resulting unreliability compounds across repeated trials in epistemically demanding domains. Thus, current LLM-based agents execute scientific workflows but do not exhibit the epistemic patterns that characterize scientific reasoning. Outcome-based evaluation cannot detect these failures, and scaffold engineering alone cannot repair them. Until reasoning itself becomes a training target, the scientific knowledge produced by such agents cannot be justified by the process that generated it.",
-      "citations": 5,
-      "highlighted": false,
-      "pillars": [
-        "evaluation"
-      ],
-      "type": "preprint",
-      "pillar_auto": true
-    },
-    {
       "doi": "10.48550/arXiv.2601.17807",
       "url": "https://arxiv.org/abs/2601.17807",
       "title": "An autonomous living database for perovskite photovoltaics",
@@ -113,44 +66,61 @@
         "perception"
       ],
       "type": "preprint",
+      "media": [],
       "pillar_auto": true
     },
     {
-      "doi": "10.48550/arXiv.2602.04696",
-      "url": "https://arxiv.org/abs/2602.04696",
-      "title": "Beyond Learning on Molecules by Weakly Supervising on Molecules",
+      "doi": "10.1039/d4cs00913d",
+      "url": "https://doi.org/10.1039/d4cs00913d",
+      "title": "From text to insight: large language models for chemical data extraction",
       "authors": [
-        "Gordan Prastalo",
+        "Mara Schilling-Wilhelmi",
+        "Martiño Ríos-García",
+        "Sherjeel Shabih",
+        "María Victoria Gil",
+        "Santiago Miret",
+        "Christoph T. Koch",
+        "José A. Márquez",
         "Kevin Maik Jablonka"
       ],
-      "venue": "arXiv",
-      "year": 2026,
-      "abstract": "Molecular representations are inherently task-dependent, yet most pre-trained molecular encoders are not. Task conditioning promises representations that reorganize based on task descriptions, but existing approaches rely on expensive labeled data. We show that weak supervision on programmatically derived molecular motifs is sufficient. Our Adaptive Chemical Embedding Model (ACE-Mol) learns from hundreds of motifs paired with natural language descriptors that are cheap to compute, trivial to scale. Conventional encoders slowly search the embedding space for task-relevant structure, whereas ACE-Mol immediately aligns its representations with the task. ACE-Mol achieves state-of-the-art performance across molecular property prediction benchmarks with interpretable, chemically meaningful representations.",
-      "citations": null,
+      "venue": "Chem. Soc. Rev.",
+      "year": 2025,
+      "abstract": "Large language models (LLMs) allow for the extraction of structured data from unstructured sources, such as scientific papers, with unprecedented accuracy and performance.",
+      "citations": 72,
       "highlighted": false,
       "pillars": [
-        "reasoning",
-        "action"
+        "perception"
       ],
-      "type": "preprint",
+      "type": "peer-reviewed",
+      "media": [
+        {
+          "label": "matextract.pub",
+          "url": "https://matextract.pub/"
+        }
+      ],
       "pillar_auto": true
     },
     {
-      "doi": "10.48550/arXiv.2602.17730",
-      "url": "https://arxiv.org/abs/2602.17730",
-      "title": "Clever Materials: When Models Identify Good Materials for the Wrong Reasons",
+      "doi": "10.1039/d5dd00109a",
+      "url": "https://doi.org/10.1039/d5dd00109a",
+      "title": "MOFChecker: a package for validating and correcting metal–organic framework (MOF) structures",
       "authors": [
-        "Kevin Maik Jablonka"
+        "Xin Jin",
+        "Kevin Maik Jablonka",
+        "Elias Moubarak",
+        "Yutao Li",
+        "Berend Smit"
       ],
-      "venue": "arXiv",
-      "year": 2026,
-      "abstract": "Machine learning can accelerate materials discovery. Models perform impressively on many benchmarks. However, strong benchmark performance does not imply that a model learned chemistry. I test a concrete alternative hypothesis: that property prediction can be driven by bibliographic confounding. Across five tasks spanning MOFs (thermal and solvent stability), perovskite solar cells (efficiency), batteries (capacity), and TADF emitters (emission wavelength), models trained on standard chemical descriptors predict author, journal, and publication year well above chance. When these predicted metadata (\"bibliographic fingerprints\") are used as the sole input to a second model, performance is sometimes competitive with conventional descriptor-based predictors. These results show that many datasets do not rule out non-chemical explanations of success. Progress requires routine falsification tests (e.g., group/time splits and metadata ablations), datasets designed to resist spurious correlations, and explicit separation of two goals: predictive utility versus evidence of chemical understanding.",
-      "citations": null,
+      "venue": "Digital Discovery",
+      "year": 2025,
+      "abstract": "MOFChecker, a package for MOF duplicate detection, geometric and charge error checking, and structure correction.",
+      "citations": 14,
       "highlighted": false,
       "pillars": [
-        "evaluation"
+        "perception"
       ],
-      "type": "preprint",
+      "type": "peer-reviewed",
+      "media": [],
       "pillar_auto": true
     },
     {
@@ -168,9 +138,11 @@
       "citations": 0,
       "highlighted": false,
       "pillars": [
-        "perception"
+        "perception",
+        "reasoning"
       ],
       "type": "peer-reviewed",
+      "media": [],
       "pillar_auto": true
     },
     {
@@ -197,34 +169,103 @@
         "reasoning"
       ],
       "type": "peer-reviewed",
+      "media": [],
       "pillar_auto": true
     },
     {
-      "doi": "10.1016/j.carbpol.2026.124890",
-      "url": "https://doi.org/10.1016/j.carbpol.2026.124890",
-      "title": "Predicting acetalated dextran nanoparticle features: Controlled synthesis, formulation, and testing in a high-throughput process",
+      "doi": "10.48550/arXiv.2505.12534",
+      "url": "https://arxiv.org/abs/2505.12534",
+      "title": "ChemPile: A 250GB Diverse and Curated Dataset for Chemical Foundation Models",
       "authors": [
-        "Thorben Köhler",
-        "Sreekanth Kunchapu",
-        "Antje Vollrath",
-        "Kourosh Rezaei",
-        "Julian Kimmig",
-        "Steffi Stumpf",
-        "Stephanie Hoeppener",
-        "Ivo Nischang",
-        "Kevin M. Jablonka",
-        "Ulrich S. Schubert",
-        "Stephanie Schubert"
+        "Adrian Mirza",
+        "Nawaf Alampara",
+        "Martiño Ríos-García",
+        "Mohamed Abdelalim",
+        "Jack Butler",
+        "Bethany Connolly",
+        "Tunca Dogan",
+        "Marianna Nezhurina",
+        "Bünyamin Şen",
+        "Santosh Tirunagari",
+        "Mark Worrall",
+        "Adamo Young",
+        "Philippe Schwaller",
+        "Michael Pieler",
+        "Kevin Maik Jablonka"
       ],
-      "venue": "Carbohydrate Polymers",
-      "year": 2026,
-      "abstract": "The hydrophobic, pH-labile, and biodegradable acetalated dextran (Ac(e)Dex) is a promising material for drug delivery in nanomedicine. However, fundamental knowledge about the structure-property relationships is still missing, which hinders its application in preclinical and clinical trials. In this study, we synthesized a library of 36 Ac(e)Dex derivatives with different molar masses, types, and degrees of functionalization. A high-throughput formulation screening (> 1000 formulations) was conducted using a liquid handling robot optimizing the concentration of polymer, the solvent, and the addition of additives. Selected formulations were scaled up and evaluated for their stability. To further correlate polymer properties with stability, a machine learning (ML) model was developed, providing a predictive tool for Ac(e)Dex nanoparticle degradation based on synthesis/formulation data. The novelty of this work lies in the integrated synthesis-to-prediction pipeline combining controlled polymer synthesis, high-throughput formulation, and ML-based stability modeling, rather than introducing new chemical mechanisms. By eludicating how structural parameters (molar mass, type, and degree of functionalization) influence formulation properties (i.e., size, dispersity, repeatability) and particle stability, this work enables standardized comparisons of Ac(e)Dex between different studies and supports its future preclinical development.",
-      "citations": 1,
+      "venue": "NeurIPS 2025",
+      "year": 2025,
+      "abstract": "Foundation models have shown remarkable success across scientific domains, yet their impact in chemistry remains limited due to the absence of diverse, large-scale, high-quality datasets that reflect the field's multifaceted nature. We present the ChemPile, an open dataset containing over 75 billion tokens of curated chemical data, specifically built for training and evaluating general-purpose models in the chemical sciences. The dataset mirrors the human learning journey through chemistry -- from educational foundations to specialized expertise -- spanning multiple modalities and content types including structured data in diverse chemical representations (SMILES, SELFIES, IUPAC names, InChI, molecular renderings), scientific and educational text, executable code, and chemical images. ChemPile integrates foundational knowledge (textbooks, lecture notes), specialized expertise (scientific articles and language-interfaced data), visual understanding (molecular structures, diagrams), and advanced reasoning (problem-solving traces and code) -- mirroring how human chemists develop expertise through diverse learning materials and experiences. Constructed through hundreds of hours of expert curation, the ChemPile captures both foundational concepts and domain-specific complexity. We provide standardized training, validation, and test splits, enabling robust benchmarking. ChemPile is openly released via HuggingFace with a consistent API, permissive license, and detailed documentation. We hope the ChemPile will serve as a catalyst for chemical AI, enabling the development of the next generation of chemical foundation models.",
+      "citations": 6,
       "highlighted": false,
       "pillars": [
-        "action"
+        "reasoning"
       ],
       "type": "peer-reviewed",
+      "media": [],
+      "pillar_auto": true
+    },
+    {
+      "doi": "10.48550/arXiv.2602.04696",
+      "url": "https://arxiv.org/abs/2602.04696",
+      "title": "Beyond Learning on Molecules by Weakly Supervising on Molecules",
+      "authors": [
+        "Gordan Prastalo",
+        "Kevin Maik Jablonka"
+      ],
+      "venue": "arXiv",
+      "year": 2026,
+      "abstract": "Molecular representations are inherently task-dependent, yet most pre-trained molecular encoders are not. Task conditioning promises representations that reorganize based on task descriptions, but existing approaches rely on expensive labeled data. We show that weak supervision on programmatically derived molecular motifs is sufficient. Our Adaptive Chemical Embedding Model (ACE-Mol) learns from hundreds of motifs paired with natural language descriptors that are cheap to compute, trivial to scale. Conventional encoders slowly search the embedding space for task-relevant structure, whereas ACE-Mol immediately aligns its representations with the task. ACE-Mol achieves state-of-the-art performance across molecular property prediction benchmarks with interpretable, chemically meaningful representations.",
+      "citations": 0,
+      "highlighted": false,
+      "pillars": [
+        "reasoning",
+        "action"
+      ],
+      "type": "preprint",
+      "media": [],
+      "pillar_auto": true
+    },
+    {
+      "doi": "10.48550/arXiv.2605.08956",
+      "url": "https://arxiv.org/abs/2605.08956",
+      "title": "Agentic AI Scientists Are Not Built For Autonomous Scientific Discovery",
+      "authors": [
+        "Harshit Bisht",
+        "Vinay Kumar",
+        "Kevin Maik Jablonka",
+        " Mausam",
+        "N. M. Anoop Krishnan"
+      ],
+      "venue": "arXiv",
+      "year": 2026,
+      "abstract": "A growing body of work pursues AI scientists capable of end-to-end autonomous scientific discovery. This position paper argues that although they already function as co-scientists, agentic AI scientists are not built for autonomous scientific discovery. We identify the following challenges in building and deploying autonomous AI scientists: (1) Problem selection is influenced by the McNamara fallacy; (2) Agents are built on large language models (LLMs) whose training corpora omit tacit procedural and failure knowledge of laboratory practice; (3) Preference optimisation during post-training compresses output diversity toward consensus; and (4) Most scientific benchmarks measure single-turn prediction accuracy and lack feedback from physical experiments back to the computational model. These challenges are not just questions of scale and scaffolding; they require revisiting fundamental design choices. To build truly autonomous AI scientists, we recommend the use of scientific simulations as verifiers for training, the design of persistent world models that represent the shifting objectives governing real investigations, the establishment of a centralized preregistration repository for all AI-generated hypotheses, and application driven by scientific need rather than tool affordance.",
+      "citations": null,
+      "highlighted": false,
+      "pillars": [
+        "evaluation"
+      ],
+      "type": "preprint",
+      "media": [],
+      "pillar_auto": true
+    },
+    {
+      "doi": "10.48550/arXiv.2602.17730",
+      "url": "https://arxiv.org/abs/2602.17730",
+      "title": "Clever Materials: When Models Identify Good Materials for the Wrong Reasons",
+      "authors": [
+        "Kevin Maik Jablonka"
+      ],
+      "venue": "arXiv",
+      "year": 2026,
+      "abstract": "Machine learning can accelerate materials discovery. Models perform impressively on many benchmarks. However, strong benchmark performance does not imply that a model learned chemistry. I test a concrete alternative hypothesis: that property prediction can be driven by bibliographic confounding. Across five tasks spanning MOFs (thermal and solvent stability), perovskite solar cells (efficiency), batteries (capacity), and TADF emitters (emission wavelength), models trained on standard chemical descriptors predict author, journal, and publication year well above chance. When these predicted metadata (\"bibliographic fingerprints\") are used as the sole input to a second model, performance is sometimes competitive with conventional descriptor-based predictors. These results show that many datasets do not rule out non-chemical explanations of success. Progress requires routine falsification tests (e.g., group/time splits and metadata ablations), datasets designed to resist spurious correlations, and explicit separation of two goals: predictive utility versus evidence of chemical understanding.",
+      "citations": null,
+      "highlighted": false,
+      "pillars": [
+        "evaluation"
+      ],
+      "type": "preprint",
+      "media": [],
       "pillar_auto": true
     },
     {
@@ -244,6 +285,7 @@
         "evaluation"
       ],
       "type": "preprint",
+      "media": [],
       "pillar_auto": true
     },
     {
@@ -264,6 +306,113 @@
         "evaluation"
       ],
       "type": "preprint",
+      "media": [],
+      "pillar_auto": true
+    },
+    {
+      "doi": "10.1016/j.commatsci.2025.114041",
+      "url": "https://doi.org/10.1016/j.commatsci.2025.114041",
+      "title": "Lessons from the trenches on evaluating machine learning systems in materials science",
+      "authors": [
+        "Nawaf Alampara",
+        "Mara Schilling-Wilhelmi",
+        "Kevin Maik Jablonka"
+      ],
+      "venue": "Computational Materials Science",
+      "year": 2025,
+      "abstract": "",
+      "citations": null,
+      "highlighted": false,
+      "pillars": [
+        "evaluation"
+      ],
+      "type": "peer-reviewed",
+      "media": [],
+      "pillar_auto": true
+    },
+    {
+      "doi": "10.1038/s43588-025-00836-3",
+      "url": "https://doi.org/10.1038/s43588-025-00836-3",
+      "title": "Probing the limitations of multimodal language models for chemistry and materials research",
+      "authors": [
+        "Nawaf Alampara",
+        "Mara Schilling-Wilhelmi",
+        "Martiño Ríos-García",
+        "Indrajeet Mandal",
+        "Pranav Khetarpal",
+        "Hargun Singh Grover",
+        "N. M. Anoop Krishnan",
+        "Kevin Maik Jablonka"
+      ],
+      "venue": "Nat Comput Sci",
+      "year": 2025,
+      "abstract": "Recent advancements in artificial intelligence have sparked interest in scientific assistants that could support researchers across the full spectrum of scientific workflows, from literature review to experimental design and data analysis. A key capability for such systems is the ability to process and reason about scientific information in both visual and textual forms—from interpreting spectroscopic data to understanding laboratory set-ups. Here we introduce MaCBench, a comprehensive benchmark for evaluating how vision language models handle real-world chemistry and materials science tasks across three core aspects: data extraction, experimental execution and results interpretation. Through a systematic evaluation of leading models, we find that although these systems show promising capabilities in basic perception tasks—achieving near-perfect performance in equipment identification and standardized data extraction—they exhibit fundamental limitations in spatial reasoning, cross-modal information synthesis and multi-step logical inference. Our insights have implications beyond chemistry and materials science, suggesting that developing reliable multimodal AI scientific assistants may require advances in curating suitable training data and approaches to training those models.",
+      "citations": 51,
+      "highlighted": false,
+      "pillars": [
+        "evaluation",
+        "perception"
+      ],
+      "type": "peer-reviewed",
+      "media": [
+        {
+          "label": "research briefing",
+          "url": "https://www.nature.com/articles/s43588-025-00871-0"
+        }
+      ],
+      "pillar_auto": true
+    },
+    {
+      "doi": "10.1038/s43588-025-00871-0",
+      "url": "https://doi.org/10.1038/s43588-025-00871-0",
+      "title": "Vision language models excel at perception but struggles with scientific reasoning",
+      "authors": [
+        "K. Jablonka",
+        "N. Krishnan"
+      ],
+      "venue": "Nat Comput Sci",
+      "year": 2025,
+      "abstract": "Evaluation of leading VLMs reveals that they excel at basic scientific tasks such as equipment identification, but struggle with spatial reasoning and multistep analysis — a limitation for autonomous scientific discovery.",
+      "citations": 1,
+      "highlighted": false,
+      "pillars": [
+        "evaluation",
+        "perception"
+      ],
+      "type": "editorial",
+      "media": [],
+      "pillar_auto": true
+    },
+    {
+      "doi": "10.48550/arXiv.2604.18805",
+      "url": "https://arxiv.org/abs/2604.18805",
+      "title": "AI scientists produce results without reasoning scientifically",
+      "authors": [
+        "Martiño Ríos-García",
+        "Nawaf Alampara",
+        "Chandan Gupta",
+        "Indrajeet Mandal",
+        "Sajid Mannan",
+        "Ali Asghar Aghajani",
+        "N. M. Anoop Krishnan",
+        "Kevin Maik Jablonka"
+      ],
+      "venue": "arXiv",
+      "year": 2026,
+      "abstract": "Large language model (LLM)-based systems are increasingly deployed to conduct scientific research autonomously, yet whether their reasoning adheres to the epistemic norms that make scientific inquiry self-correcting is poorly understood. Here, we evaluate LLM-based scientific agents across eight domains, spanning workflow execution to hypothesis-driven inquiry, through more than 25,000 agent runs and two complementary lenses: (i) a systematic performance analysis that decomposes the contributions of the base model and the agent scaffold, and (ii) a behavioral analysis of the epistemological structure of agent reasoning. We observe that the base model is the primary determinant of both performance and behavior, accounting for 41.4% of explained variance versus 1.5% for the scaffold. Across all configurations, evidence is ignored in 68% of traces, refutation-driven belief revision occurs in 26%, and convergent multi-test evidence is rare. The same reasoning pattern appears whether the agent executes a computational workflow or conducts hypothesis-driven inquiry. They persist even when agents receive near-complete successful reasoning trajectories as context, and the resulting unreliability compounds across repeated trials in epistemically demanding domains. Thus, current LLM-based agents execute scientific workflows but do not exhibit the epistemic patterns that characterize scientific reasoning. Outcome-based evaluation cannot detect these failures, and scaffold engineering alone cannot repair them. Until reasoning itself becomes a training target, the scientific knowledge produced by such agents cannot be justified by the process that generated it.",
+      "citations": null,
+      "highlighted": false,
+      "pillars": [
+        "evaluation",
+        "reasoning"
+      ],
+      "type": "preprint",
+      "media": [
+        {
+          "label": "Science News",
+          "url": "https://www.sciencenews.org/article/ai-ignore-evidence-trust-science"
+        }
+      ],
       "pillar_auto": true
     },
     {
@@ -317,6 +466,24 @@
         "reasoning"
       ],
       "type": "peer-reviewed",
+      "media": [
+        {
+          "label": "chembench.lamalab.org",
+          "url": "http://chembench.lamalab.org/"
+        },
+        {
+          "label": "Chemistry World",
+          "url": "https://www.chemistryworld.com/news/large-language-models-are-better-than-humans-at-answering-chemistry-questions/4020562.article"
+        },
+        {
+          "label": "State of AI 2025",
+          "url": "https://www.stateof.ai"
+        },
+        {
+          "label": "research briefing",
+          "url": "https://www.nature.com/articles/s41557-025-01865-1"
+        }
+      ],
       "pillar_auto": true
     },
     {
@@ -336,6 +503,134 @@
         "reasoning"
       ],
       "type": "editorial",
+      "media": [],
+      "pillar_auto": true
+    },
+    {
+      "doi": "10.48550/arXiv.2406.17295",
+      "url": "https://arxiv.org/abs/2406.17295",
+      "title": "Less can be more for predicting properties with large language models",
+      "authors": [
+        "Nawaf Alampara",
+        "Santiago Miret",
+        "Kevin Maik Jablonka"
+      ],
+      "venue": "arXiv",
+      "year": 2024,
+      "abstract": "Predicting properties from coordinate-category data -- sets of vectors paired with categorical information -- is fundamental to computational science. In materials science, this challenge manifests as predicting properties like formation energies or elastic moduli from crystal structures comprising atomic positions (vectors) and element types (categorical information). While large language models (LLMs) have increasingly been applied to such tasks, with researchers encoding structural data as text, optimal strategies for achieving reliable predictions remain elusive. Here, we report fundamental limitations in LLM's ability to learn from coordinate information in coordinate-category data. Through systematic experiments using synthetic datasets with tunable coordinate and category contributions, combined with a comprehensive benchmarking framework (MatText) spanning multiple representations and model scales, we find that LLMs consistently fail to capture coordinate information while excelling at category patterns. This geometric blindness persists regardless of model size (up to 70B parameters), dataset scale (up to 2M structures), or text representation strategy. Our findings suggest immediate practical implications: for materials property prediction tasks dominated by structural effects, specialized geometric architectures consistently outperform LLMs by significant margins, as evidenced by a clear \"GNN-LM wall\" in performance benchmarks. Based on our analysis, we provide concrete guidelines for architecture selection in scientific machine learning, while highlighting the critical importance of understanding model inductive biases when tackling scientific prediction problems.",
+      "citations": null,
+      "highlighted": false,
+      "pillars": [
+        "evaluation",
+        "action"
+      ],
+      "type": "preprint",
+      "media": [],
+      "pillar_auto": true
+    },
+    {
+      "doi": "10.1016/j.carbpol.2026.124890",
+      "url": "https://doi.org/10.1016/j.carbpol.2026.124890",
+      "title": "Predicting acetalated dextran nanoparticle features: Controlled synthesis, formulation, and testing in a high-throughput process",
+      "authors": [
+        "Thorben Köhler",
+        "Sreekanth Kunchapu",
+        "Antje Vollrath",
+        "Kourosh Rezaei",
+        "Julian Kimmig",
+        "Steffi Stumpf",
+        "Stephanie Hoeppener",
+        "Ivo Nischang",
+        "Kevin M. Jablonka",
+        "Ulrich S. Schubert",
+        "Stephanie Schubert"
+      ],
+      "venue": "Carbohydrate Polymers",
+      "year": 2026,
+      "abstract": "The hydrophobic, pH-labile, and biodegradable acetalated dextran (Ac(e)Dex) is a promising material for drug delivery in nanomedicine. However, fundamental knowledge about the structure-property relationships is still missing, which hinders its application in preclinical and clinical trials. In this study, we synthesized a library of 36 Ac(e)Dex derivatives with different molar masses, types, and degrees of functionalization. A high-throughput formulation screening (> 1000 formulations) was conducted using a liquid handling robot optimizing the concentration of polymer, the solvent, and the addition of additives. Selected formulations were scaled up and evaluated for their stability. To further correlate polymer properties with stability, a machine learning (ML) model was developed, providing a predictive tool for Ac(e)Dex nanoparticle degradation based on synthesis/formulation data. The novelty of this work lies in the integrated synthesis-to-prediction pipeline combining controlled polymer synthesis, high-throughput formulation, and ML-based stability modeling, rather than introducing new chemical mechanisms. By eludicating how structural parameters (molar mass, type, and degree of functionalization) influence formulation properties (i.e., size, dispersity, repeatability) and particle stability, this work enables standardized comparisons of Ac(e)Dex between different studies and supports its future preclinical development.",
+      "citations": 1,
+      "highlighted": false,
+      "pillars": [
+        "action"
+      ],
+      "type": "peer-reviewed",
+      "media": [],
+      "pillar_auto": true
+    },
+    {
+      "doi": "10.1038/s41524-025-01823-y",
+      "url": "https://doi.org/10.1038/s41524-025-01823-y",
+      "title": "PolyMetriX: an ecosystem for digital polymer chemistry",
+      "authors": [
+        "Sreekanth Kunchapu",
+        "Kevin Maik Jablonka"
+      ],
+      "venue": "npj Comput Mater",
+      "year": 2025,
+      "abstract": "Digital polymer chemistry leverages computational methods to design and optimize polymer materials. While there have been advances in using machine learning to accelerate the design of polymers, the field is hampered by the lack of standards, which precludes comparability and makes it difficult to build on top of prior work. To address this gap, we introduce PolyMetriX, an open-source Python library designed to facilitate the entire polymer informatics workflow—from obtaining data to training models. PolyMetriX provides curated polymer property datasets, and novel featurization techniques that extract hierarchical structural information at the full polymer, backbone, and sidechain levels. Additionally, it incorporates polymer-specific data splitting strategies to ensure robust model generalization. PolyMetriX enhances the predictive performance of models while improving reproducibility in digital polymer chemistry.",
+      "citations": 7,
+      "highlighted": false,
+      "pillars": [
+        "action"
+      ],
+      "type": "peer-reviewed",
+      "media": [],
+      "pillar_auto": true
+    },
+    {
+      "doi": "10.26434/chemrxiv.15004102/v2",
+      "url": "https://doi.org/10.26434/chemrxiv.15004102/v2",
+      "title": "Condition-aware prediction of copolymer architecture",
+      "authors": [
+        "Mara Schilling-Wilhelmi",
+        "Boris Bulgakov",
+        "Luc Patiny",
+        "Sarthak Kapoor",
+        "Kevin Maik Jablonka"
+      ],
+      "venue": "",
+      "year": 2026,
+      "abstract": "The architecture of a copolymer determines how the material behaves. Designing a polymer for a target property, therefore, should begin with designing for a target architecture. Yet no method predicts the architecture a given monomer pair will react to under given conditions. Even though reactivity ratios have been known since Mayo and Lewis to depend on solvent, temperature, and polymerization mechanism, every predictive approach, from the Q–e scheme of Alfrey and Price to recent machine-learning models, takes monomer structure alone as input. Measurements for thousands of monomer pairs exist but are scattered across eight decades of literature, much of it predating machine-readable publishing and surviving only as scanned page images. We address this gap with PolyCARP, a classifier that predicts copolymer architecture from monomer pair and reaction conditions before any synthesis, trained on a database we extracted from the literature. A vision–language-model pipeline parses 1,206 publications, yielding 3,791 copolymerizations annotated with reactivity ratios, solvent, temperature, and polymerization mechanism. This, to our knowledge, is the first dataset at this scale to record reaction conditions per entry. For any monomer pair and set of conditions, PolyCARP returns an architecture class and the nearest experimental analogues in the database. We validate the tool against a literature case study, where it captures solvent-driven architectural transitions, and against three prospective laboratory copolymerizations. The database, model, and code are openly released—enabling the community to extend both data and models, and to make more of polymer chemistry predictable.",
+      "citations": null,
+      "highlighted": false,
+      "pillars": [
+        "action",
+        "perception"
+      ],
+      "type": "preprint",
+      "media": [],
+      "pillar_auto": true
+    },
+    {
+      "doi": "10.1038/s42256-023-00788-1",
+      "url": "https://doi.org/10.1038/s42256-023-00788-1",
+      "title": "Leveraging large language models for predictive chemistry",
+      "authors": [
+        "Kevin Maik Jablonka",
+        "Philippe Schwaller",
+        "Andres Ortega-Guerrero",
+        "Berend Smit"
+      ],
+      "venue": "Nat Mach Intell",
+      "year": 2024,
+      "abstract": "Machine learning has transformed many fields and has recently found applications in chemistry and materials science. The small datasets commonly found in chemistry sparked the development of sophisticated machine learning approaches that incorporate chemical knowledge for each application and, therefore, require specialized expertise to develop. Here we show that GPT-3, a large language model trained on vast amounts of text extracted from the Internet, can easily be adapted to solve various tasks in chemistry and materials science by fine-tuning it to answer chemical questions in natural language with the correct answer. We compared this approach with dedicated machine learning models for many applications spanning the properties of molecules and materials to the yield of chemical reactions. Surprisingly, our fine-tuned version of GPT-3 can perform comparably to or even outperform conventional machine learning techniques, in particular in the low-data limit. In addition, we can perform inverse design by simply inverting the questions. The ease of use and high performance, especially for small datasets, can impact the fundamental approach to using machine learning in the chemical and material sciences. In addition to a literature search, querying a pre-trained large language model might become a routine way to bootstrap a project by leveraging the collective knowledge encoded in these foundation models, or to provide a baseline for predictive tasks.",
+      "citations": 379,
+      "highlighted": false,
+      "pillars": [
+        "action",
+        "reasoning"
+      ],
+      "type": "peer-reviewed",
+      "media": [
+        {
+          "label": "MIT Technology Review",
+          "url": "https://www.technologyreview.com/2023/03/25/1070275/chatgpt-revolutionize-economy-decide-what-looks-like/"
+        },
+        {
+          "label": "Nature News",
+          "url": "https://www.nature.com/articles/d41586-024-00347-7"
+        }
+      ],
       "pillar_auto": true
     },
     {
@@ -401,108 +696,10 @@
       "highlighted": false,
       "pillars": [
         "action",
-        "reasoning"
-      ],
-      "type": "peer-reviewed",
-      "pillar_auto": true
-    },
-    {
-      "doi": "10.48550/arXiv.2505.12534",
-      "url": "https://arxiv.org/abs/2505.12534",
-      "title": "ChemPile: A 250GB Diverse and Curated Dataset for Chemical Foundation Models",
-      "authors": [
-        "Adrian Mirza",
-        "Nawaf Alampara",
-        "Martiño Ríos-García",
-        "Mohamed Abdelalim",
-        "Jack Butler",
-        "Bethany Connolly",
-        "Tunca Dogan",
-        "Marianna Nezhurina",
-        "Bünyamin Şen",
-        "Santosh Tirunagari",
-        "Mark Worrall",
-        "Adamo Young",
-        "Philippe Schwaller",
-        "Michael Pieler",
-        "Kevin Maik Jablonka"
-      ],
-      "venue": "NeurIPS 2025",
-      "year": 2025,
-      "abstract": "Foundation models have shown remarkable success across scientific domains, yet their impact in chemistry remains limited due to the absence of diverse, large-scale, high-quality datasets that reflect the field's multifaceted nature. We present the ChemPile, an open dataset containing over 75 billion tokens of curated chemical data, specifically built for training and evaluating general-purpose models in the chemical sciences. The dataset mirrors the human learning journey through chemistry -- from educational foundations to specialized expertise -- spanning multiple modalities and content types including structured data in diverse chemical representations (SMILES, SELFIES, IUPAC names, InChI, molecular renderings), scientific and educational text, executable code, and chemical images. ChemPile integrates foundational knowledge (textbooks, lecture notes), specialized expertise (scientific articles and language-interfaced data), visual understanding (molecular structures, diagrams), and advanced reasoning (problem-solving traces and code) -- mirroring how human chemists develop expertise through diverse learning materials and experiences. Constructed through hundreds of hours of expert curation, the ChemPile captures both foundational concepts and domain-specific complexity. We provide standardized training, validation, and test splits, enabling robust benchmarking. ChemPile is openly released via HuggingFace with a consistent API, permissive license, and detailed documentation. We hope the ChemPile will serve as a catalyst for chemical AI, enabling the development of the next generation of chemical foundation models.",
-      "citations": null,
-      "highlighted": false,
-      "pillars": [
-        "reasoning"
-      ],
-      "type": "peer-reviewed",
-      "pillar_auto": true
-    },
-    {
-      "doi": "10.1039/d4cs00913d",
-      "url": "https://doi.org/10.1039/d4cs00913d",
-      "title": "From text to insight: large language models for chemical data extraction",
-      "authors": [
-        "Mara Schilling-Wilhelmi",
-        "Martiño Ríos-García",
-        "Sherjeel Shabih",
-        "María Victoria Gil",
-        "Santiago Miret",
-        "Christoph T. Koch",
-        "José A. Márquez",
-        "Kevin Maik Jablonka"
-      ],
-      "venue": "Chem. Soc. Rev.",
-      "year": 2025,
-      "abstract": "Large language models (LLMs) allow for the extraction of structured data from unstructured sources, such as scientific papers, with unprecedented accuracy and performance.",
-      "citations": 72,
-      "highlighted": false,
-      "pillars": [
-        "perception"
-      ],
-      "type": "peer-reviewed",
-      "pillar_auto": true
-    },
-    {
-      "doi": "10.1016/j.commatsci.2025.114041",
-      "url": "https://doi.org/10.1016/j.commatsci.2025.114041",
-      "title": "Lessons from the trenches on evaluating machine learning systems in materials science",
-      "authors": [
-        "Nawaf Alampara",
-        "Mara Schilling-Wilhelmi",
-        "Kevin Maik Jablonka"
-      ],
-      "venue": "Computational Materials Science",
-      "year": 2025,
-      "abstract": "",
-      "citations": null,
-      "highlighted": false,
-      "pillars": [
         "evaluation"
       ],
       "type": "peer-reviewed",
-      "pillar_auto": true
-    },
-    {
-      "doi": "10.1039/d5dd00109a",
-      "url": "https://doi.org/10.1039/d5dd00109a",
-      "title": "MOFChecker: a package for validating and correcting metal–organic framework (MOF) structures",
-      "authors": [
-        "Xin Jin",
-        "Kevin Maik Jablonka",
-        "Elias Moubarak",
-        "Yutao Li",
-        "Berend Smit"
-      ],
-      "venue": "Digital Discovery",
-      "year": 2025,
-      "abstract": "MOFChecker, a package for MOF duplicate detection, geometric and charge error checking, and structure correction.",
-      "citations": 14,
-      "highlighted": false,
-      "pillars": [
-        "perception"
-      ],
-      "type": "peer-reviewed",
+      "media": [],
       "pillar_auto": true
     },
     {
@@ -527,51 +724,7 @@
         "community"
       ],
       "type": "editorial",
-      "pillar_auto": true
-    },
-    {
-      "doi": "10.1038/s41524-025-01823-y",
-      "url": "https://doi.org/10.1038/s41524-025-01823-y",
-      "title": "PolyMetriX: an ecosystem for digital polymer chemistry",
-      "authors": [
-        "Sreekanth Kunchapu",
-        "Kevin Maik Jablonka"
-      ],
-      "venue": "npj Comput Mater",
-      "year": 2025,
-      "abstract": "Digital polymer chemistry leverages computational methods to design and optimize polymer materials. While there have been advances in using machine learning to accelerate the design of polymers, the field is hampered by the lack of standards, which precludes comparability and makes it difficult to build on top of prior work. To address this gap, we introduce PolyMetriX, an open-source Python library designed to facilitate the entire polymer informatics workflow—from obtaining data to training models. PolyMetriX provides curated polymer property datasets, and novel featurization techniques that extract hierarchical structural information at the full polymer, backbone, and sidechain levels. Additionally, it incorporates polymer-specific data splitting strategies to ensure robust model generalization. PolyMetriX enhances the predictive performance of models while improving reproducibility in digital polymer chemistry.",
-      "citations": 7,
-      "highlighted": false,
-      "pillars": [
-        "action"
-      ],
-      "type": "peer-reviewed",
-      "pillar_auto": true
-    },
-    {
-      "doi": "10.1038/s43588-025-00836-3",
-      "url": "https://doi.org/10.1038/s43588-025-00836-3",
-      "title": "Probing the limitations of multimodal language models for chemistry and materials research",
-      "authors": [
-        "Nawaf Alampara",
-        "Mara Schilling-Wilhelmi",
-        "Martiño Ríos-García",
-        "Indrajeet Mandal",
-        "Pranav Khetarpal",
-        "Hargun Singh Grover",
-        "N. M. Anoop Krishnan",
-        "Kevin Maik Jablonka"
-      ],
-      "venue": "Nat Comput Sci",
-      "year": 2025,
-      "abstract": "Recent advancements in artificial intelligence have sparked interest in scientific assistants that could support researchers across the full spectrum of scientific workflows, from literature review to experimental design and data analysis. A key capability for such systems is the ability to process and reason about scientific information in both visual and textual forms—from interpreting spectroscopic data to understanding laboratory set-ups. Here we introduce MaCBench, a comprehensive benchmark for evaluating how vision language models handle real-world chemistry and materials science tasks across three core aspects: data extraction, experimental execution and results interpretation. Through a systematic evaluation of leading models, we find that although these systems show promising capabilities in basic perception tasks—achieving near-perfect performance in equipment identification and standardized data extraction—they exhibit fundamental limitations in spatial reasoning, cross-modal information synthesis and multi-step logical inference. Our insights have implications beyond chemistry and materials science, suggesting that developing reliable multimodal AI scientific assistants may require advances in curating suitable training data and approaches to training those models.",
-      "citations": 51,
-      "highlighted": false,
-      "pillars": [
-        "evaluation",
-        "perception"
-      ],
-      "type": "peer-reviewed",
+      "media": [],
       "pillar_auto": true
     },
     {
@@ -591,26 +744,7 @@
         "community"
       ],
       "type": "editorial",
-      "pillar_auto": true
-    },
-    {
-      "doi": "10.1038/s43588-025-00871-0",
-      "url": "https://doi.org/10.1038/s43588-025-00871-0",
-      "title": "Vision language models excel at perception but struggles with scientific reasoning",
-      "authors": [
-        "K. Jablonka",
-        "N. Krishnan"
-      ],
-      "venue": "Nat Comput Sci",
-      "year": 2025,
-      "abstract": "Evaluation of leading VLMs reveals that they excel at basic scientific tasks such as equipment identification, but struggle with spatial reasoning and multistep analysis — a limitation for autonomous scientific discovery.",
-      "citations": 1,
-      "highlighted": false,
-      "pillars": [
-        "evaluation",
-        "perception"
-      ],
-      "type": "editorial",
+      "media": [],
       "pillar_auto": true
     },
     {
@@ -640,49 +774,7 @@
         "community"
       ],
       "type": "editorial",
-      "pillar_auto": true
-    },
-    {
-      "doi": "10.48550/arXiv.2406.17295",
-      "url": "https://arxiv.org/abs/2406.17295",
-      "title": "Less can be more for predicting properties with large language models",
-      "authors": [
-        "Nawaf Alampara",
-        "Santiago Miret",
-        "Kevin Maik Jablonka"
-      ],
-      "venue": "arXiv",
-      "year": 2024,
-      "abstract": "Predicting properties from coordinate-category data -- sets of vectors paired with categorical information -- is fundamental to computational science. In materials science, this challenge manifests as predicting properties like formation energies or elastic moduli from crystal structures comprising atomic positions (vectors) and element types (categorical information). While large language models (LLMs) have increasingly been applied to such tasks, with researchers encoding structural data as text, optimal strategies for achieving reliable predictions remain elusive. Here, we report fundamental limitations in LLM's ability to learn from coordinate information in coordinate-category data. Through systematic experiments using synthetic datasets with tunable coordinate and category contributions, combined with a comprehensive benchmarking framework (MatText) spanning multiple representations and model scales, we find that LLMs consistently fail to capture coordinate information while excelling at category patterns. This geometric blindness persists regardless of model size (up to 70B parameters), dataset scale (up to 2M structures), or text representation strategy. Our findings suggest immediate practical implications: for materials property prediction tasks dominated by structural effects, specialized geometric architectures consistently outperform LLMs by significant margins, as evidenced by a clear \"GNN-LM wall\" in performance benchmarks. Based on our analysis, we provide concrete guidelines for architecture selection in scientific machine learning, while highlighting the critical importance of understanding model inductive biases when tackling scientific prediction problems.",
-      "citations": null,
-      "highlighted": false,
-      "pillars": [
-        "evaluation",
-        "action"
-      ],
-      "type": "preprint",
-      "pillar_auto": true
-    },
-    {
-      "doi": "10.1038/s42256-023-00788-1",
-      "url": "https://doi.org/10.1038/s42256-023-00788-1",
-      "title": "Leveraging large language models for predictive chemistry",
-      "authors": [
-        "Kevin Maik Jablonka",
-        "Philippe Schwaller",
-        "Andres Ortega-Guerrero",
-        "Berend Smit"
-      ],
-      "venue": "Nat Mach Intell",
-      "year": 2024,
-      "abstract": "Machine learning has transformed many fields and has recently found applications in chemistry and materials science. The small datasets commonly found in chemistry sparked the development of sophisticated machine learning approaches that incorporate chemical knowledge for each application and, therefore, require specialized expertise to develop. Here we show that GPT-3, a large language model trained on vast amounts of text extracted from the Internet, can easily be adapted to solve various tasks in chemistry and materials science by fine-tuning it to answer chemical questions in natural language with the correct answer. We compared this approach with dedicated machine learning models for many applications spanning the properties of molecules and materials to the yield of chemical reactions. Surprisingly, our fine-tuned version of GPT-3 can perform comparably to or even outperform conventional machine learning techniques, in particular in the low-data limit. In addition, we can perform inverse design by simply inverting the questions. The ease of use and high performance, especially for small datasets, can impact the fundamental approach to using machine learning in the chemical and material sciences. In addition to a literature search, querying a pre-trained large language model might become a routine way to bootstrap a project by leveraging the collective knowledge encoded in these foundation models, or to provide a baseline for predictive tasks.",
-      "citations": 379,
-      "highlighted": false,
-      "pillars": [
-        "action",
-        "reasoning"
-      ],
-      "type": "peer-reviewed",
+      "media": [],
       "pillar_auto": true
     },
     {
@@ -716,6 +808,7 @@
         "community"
       ],
       "type": "editorial",
+      "media": [],
       "pillar_auto": true
     },
     {
@@ -786,6 +879,7 @@
         "community"
       ],
       "type": "peer-reviewed",
+      "media": [],
       "pillar_auto": true
     }
   ]

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -11,12 +11,13 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <title>{{ if .IsPage }} {{ .Title }} | {{ end }}{{ .Site.Title }}</title>
   <link rel = 'canonical' href = '{{ .Permalink }}'>
-  {{ with .Site.Params.description }}<meta name="description" content="{{ . }}">{{ end }}
+  {{ with (or .Description .Site.Params.description) }}<meta name="description" content="{{ . }}">{{ end }}
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="robots" content="all,follow">
   <meta name="googlebot" content="index,follow,snippet,archive">
   {{ template "_internal/opengraph.html" . }}
   {{ template "_internal/twitter_cards.html" . }}
+  {{ partial "structured-data.html" . }}
   {{ .Scratch.Set "colortheme" "white"}}
   {{ if .Site.Params.Colortheme }}
     {{ .Scratch.Set "colortheme" .Site.Params.Colortheme }}

--- a/layouts/partials/structured-data.html
+++ b/layouts/partials/structured-data.html
@@ -1,0 +1,34 @@
+{{- if .IsHome -}}
+{{- $base := .Site.BaseURL -}}
+{{- $graph := slice
+    (dict
+      "@type" (slice "EducationalOrganization" "ResearchOrganization")
+      "@id" (printf "%s#organization" $base)
+      "name" .Site.Title
+      "alternateName" (slice "LamaLab" "Laboratory for AI in Materials Science")
+      "url" $base
+      "description" .Site.Params.description
+      "parentOrganization" (dict "@type" "CollegeOrUniversity" "name" "Friedrich Schiller University Jena" "url" "https://www.uni-jena.de/")
+      "founder" (dict "@id" (printf "%s#kevin" $base))
+      "member" (dict "@id" (printf "%s#kevin" $base))
+      "sameAs" (slice "https://github.com/lamalab-org" "https://lamalaborg.substack.com"))
+    (dict
+      "@type" "Person"
+      "@id" (printf "%s#kevin" $base)
+      "name" "Kevin Maik Jablonka"
+      "givenName" "Kevin Maik"
+      "familyName" "Jablonka"
+      "jobTitle" "Group Leader"
+      "url" $base
+      "affiliation" (dict "@type" "CollegeOrUniversity" "name" "Friedrich Schiller University Jena" "url" "https://www.uni-jena.de/")
+      "worksFor" (dict "@id" (printf "%s#organization" $base))
+      "sameAs" (slice
+        "https://scholar.google.com/citations?user=R2ntI8IAAAAJ&hl=en"
+        "https://orcid.org/0000-0003-4894-4660"
+        "https://github.com/kjappelbaum"
+        "https://kjablonka.com"))
+-}}
+<script type="application/ld+json">
+{{ (dict "@context" "https://schema.org" "@graph" $graph) | jsonify (dict "indent" "  ") | safeJS }}
+</script>
+{{- end -}}

--- a/layouts/shortcodes/publications.html
+++ b/layouts/shortcodes/publications.html
@@ -1,4 +1,17 @@
 {{- $data := .Site.Data.publications -}}
+{{- /* structured data: the publication list, for search engines */ -}}
+{{- $items := slice -}}
+{{- range $i, $p := $data.papers -}}
+    {{- $authors := slice -}}
+    {{- range $p.authors -}}{{- $authors = $authors | append (dict "@type" "Person" "name" .) -}}{{- end -}}
+    {{- $article := dict "@type" "ScholarlyArticle" "name" $p.title "headline" $p.title "url" $p.url "sameAs" $p.url "author" $authors -}}
+    {{- with $p.year -}}{{- $article = merge $article (dict "datePublished" (printf "%.0f" .)) -}}{{- end -}}
+    {{- with $p.venue -}}{{- $article = merge $article (dict "isPartOf" (dict "@type" "Periodical" "name" .)) -}}{{- end -}}
+    {{- $items = $items | append (dict "@type" "ListItem" "position" (add $i 1) "item" $article) -}}
+{{- end -}}
+<script type="application/ld+json">
+{{ (dict "@context" "https://schema.org" "@type" "ItemList" "name" "Publications — Lab for AI in Materials Science" "itemListElement" $items) | jsonify (dict "indent" "  ") | safeJS }}
+</script>
 <style>
     .pub-landscape { width: 100%; height: 520px; margin: 1.5rem 0 0.5rem;
         border: 1px solid var(--border-color, #E0E0E0); border-radius: 6px; }
@@ -43,10 +56,12 @@
     .pub-abstract.open { -webkit-line-clamp: unset; }
     .pub-more { font-family: "JetBrains Mono", monospace; font-size: 0.75rem; background: none;
         border: none; padding: 0.2rem 0; cursor: pointer; color: var(--primary-color, #A43830); }
+    .pub-media { font-size: 0.8rem; color: var(--secondary-color, #666); margin-top: 0.35rem; }
+    .pub-attrib { font-size: 0.72rem; color: var(--secondary-color, #888); margin: 1.75rem 0 0; }
 </style>
 
 <div id="pub-landscape" class="pub-landscape"></div>
-<p class="pub-hint">each paper sits on the research thread(s) it belongs to — papers shared by two threads sit between them, linked to both · hover to peek · click to jump · use the legend to toggle threads</p>
+<p class="pub-hint">columns are the research threads, each row is a paper (grouped by thread) — a dot marks each membership and a line links the threads a paper spans · hover to peek · click to jump · toggle threads in the legend</p>
 
 <ul class="pub-threads">
     {{- range $data.threads }}
@@ -80,7 +95,7 @@
         </h3>
         <div class="pub-meta">
             <span class="pub-authors">{{ delimit (first 8 .authors) ", " }}{{ if gt (len .authors) 8 }}, et al.{{ end }}</span><br>
-            {{ with .venue }}{{ . }} · {{ end }}{{ .year }}{{ if .citations }}{{ if gt .citations 0.0 }} · {{ .citations }} citations{{ end }}{{ end }}
+            {{ with .venue }}{{ . }} · {{ end }}{{ .year }}{{ if .citations }}{{ if gt .citations 0.0 }} · <span title="citation count via Semantic Scholar">{{ .citations }} citations</span>{{ end }}{{ end }}
             &nbsp; <span class="pub-tags">
                 {{- range .pillars }}{{ $t := index (where $data.threads "name" .) 0 }}{{ with $t }}<span class="pub-topic"><span class="pub-dot" style="background:{{ .color }}"></span>{{ .name }}</span>{{ end }}{{ end }}
                 {{ if ne .type "peer-reviewed" }}<span class="pub-type">{{ .type }}</span>{{ end }}
@@ -90,9 +105,14 @@
         <div class="pub-abstract">{{ . }}</div>
         <button class="pub-more" onclick="this.previousElementSibling.classList.toggle('open');this.textContent=this.previousElementSibling.classList.contains('open')?'show less':'show more'">show more</button>
         {{ end }}
+        {{ with .media }}
+        <div class="pub-media">also: {{ range $i, $m := . }}{{ if $i }} · {{ end }}<a href="{{ $m.url }}" target="_blank" rel="noopener">{{ $m.label }}</a>{{ end }}</div>
+        {{ end }}
     </div>
     {{- end -}}
 </div>
+
+<p class="pub-attrib">metadata from CrossRef, Semantic Scholar &amp; arXiv · citation counts from Semantic Scholar · media links curated by us</p>
 
 <script src="https://cdn.plot.ly/plotly-2.35.2.min.js" charset="utf-8"></script>
 <script>
@@ -100,78 +120,65 @@
     var DATA = JSON.parse({{ $data | jsonify }});
     var idOf = function (doi) { return "pub-" + doi.replace(/[^a-zA-Z0-9]+/g, "-"); };
     var threads = DATA.threads, n = threads.length;
+    var colx = {}; threads.forEach(function (t, i) { colx[t.name] = i; });
 
-    // place each thread on a circle; papers sit at the mean of their threads' anchors
-    var anchors = {};
-    threads.forEach(function (t, i) {
-        var a = -Math.PI / 2 + (i / n) * 2 * Math.PI;
-        anchors[t.name] = { x: Math.cos(a), y: Math.sin(a) };
-    });
-    var hash = function (s) {
-        var h = 2166136261;
-        for (var i = 0; i < s.length; i++) { h ^= s.charCodeAt(i); h = Math.imul(h, 16777619); }
-        return h >>> 0;
-    };
-    DATA.papers.forEach(function (p) {
-        var ps = (p.pillars || []).filter(function (x) { return anchors[x]; });
+    // incidence matrix: threads are columns, papers are rows (already ordered by
+    // build.py so primary-thread blocks are contiguous). A dot marks each
+    // membership; a connector spans the threads a shared paper belongs to.
+    var rows = DATA.papers.map(function (p, idx) {
+        var ps = (p.pillars || []).filter(function (x) { return colx[x] !== undefined; });
         if (!ps.length) ps = [threads[0].name];
-        var cx = 0, cy = 0;
-        ps.forEach(function (x) { cx += anchors[x].x; cy += anchors[x].y; });
-        cx /= ps.length; cy /= ps.length;
-        var h = hash(p.doi), ang = (h % 628) / 100, rad = 0.10 + ((h >>> 9) % 100) / 100 * 0.16;
-        p._x = cx + rad * Math.cos(ang); p._y = cy + rad * Math.sin(ang); p._ps = ps;
+        return { p: p, ps: ps, cols: ps.map(function (x) { return colx[x]; }), y: -idx };
     });
+    var R = rows.length;
 
-    // faint links from a shared paper to each of its threads
+    var el = document.getElementById("pub-landscape");
+    el.style.height = Math.max(420, Math.min(1500, R * 22 + 96)) + "px";
+
+    // horizontal connector for papers spanning more than one thread
     var lx = [], ly = [];
-    DATA.papers.forEach(function (p) {
-        if (p._ps.length > 1) p._ps.forEach(function (x) {
-            lx.push(p._x, anchors[x].x, null); ly.push(p._y, anchors[x].y, null);
-        });
+    rows.forEach(function (row) {
+        if (row.cols.length > 1) {
+            lx.push(Math.min.apply(null, row.cols), Math.max.apply(null, row.cols), null);
+            ly.push(row.y, row.y, null);
+        }
     });
     var linkTrace = { x: lx, y: ly, mode: "lines", type: "scatter", hoverinfo: "skip",
-        showlegend: false, line: { color: "rgba(120,120,120,0.28)", width: 1 } };
+        showlegend: false, line: { color: "rgba(120,120,120,0.4)", width: 1 } };
 
-    // soft halo disc at each thread anchor
-    var anchorTrace = {
-        x: threads.map(function (t) { return anchors[t.name].x; }),
-        y: threads.map(function (t) { return anchors[t.name].y; }),
-        mode: "markers", type: "scatter", hoverinfo: "skip", showlegend: false,
-        marker: { size: 48, color: threads.map(function (t) { return t.color; }), opacity: 0.12 }
-    };
-
-    // one point trace per thread (coloured by the paper's primary thread)
-    var pointTraces = threads.map(function (t) {
-        var pts = DATA.papers.filter(function (p) { return p._ps[0] === t.name; });
+    // one dot trace per thread (a dot wherever a paper belongs to that thread)
+    var dotTraces = threads.map(function (t) {
+        var rs = rows.filter(function (row) { return row.ps.indexOf(t.name) >= 0; });
         return {
             name: t.name,
-            x: pts.map(function (p) { return p._x; }),
-            y: pts.map(function (p) { return p._y; }),
-            customdata: pts.map(function (p) { return [p.title, p.venue || "", p.year, idOf(p.doi)]; }),
+            x: rs.map(function () { return colx[t.name]; }),
+            y: rs.map(function (row) { return row.y; }),
+            customdata: rs.map(function (row) { return [row.p.title, row.p.venue || "", row.p.year, idOf(row.p.doi)]; }),
             mode: "markers", type: "scatter",
-            marker: { color: t.color, size: 11, line: { width: 1, color: "rgba(255,255,255,0.85)" }, opacity: 0.95 },
+            marker: { color: t.color, size: 11, line: { width: 1, color: "rgba(255,255,255,0.85)" } },
             hovertemplate: "<b>%{customdata[0]}</b><br>%{customdata[1]} · %{customdata[2]}<extra></extra>"
         };
     });
 
-    var hidden = { showgrid: false, zeroline: false, showticklabels: false, title: "", range: [-1.6, 1.6] };
     var layout = {
-        hovermode: "closest", dragmode: "pan", margin: { l: 10, r: 10, t: 10, b: 10 },
-        xaxis: hidden,
-        yaxis: { showgrid: false, zeroline: false, showticklabels: false, title: "",
-                 range: [-1.6, 1.6], scaleanchor: "x", scaleratio: 1 },
-        legend: { orientation: "h", y: -0.03, font: { size: 11 } },
+        hovermode: "closest", dragmode: false,
+        margin: { l: 14, r: 14, t: 10, b: 40 },
+        xaxis: { showgrid: false, zeroline: false, showticklabels: false, range: [-0.6, n - 0.4], fixedrange: true },
+        yaxis: { showgrid: false, zeroline: false, showticklabels: false, range: [-(R - 1) - 1.0, 1.8], fixedrange: true },
+        legend: { orientation: "h", y: -0.04, font: { size: 11 } },
         paper_bgcolor: "rgba(0,0,0,0)", plot_bgcolor: "rgba(0,0,0,0)",
         hoverlabel: { align: "left", bgcolor: "#fff", bordercolor: "#A43830" },
-        annotations: threads.map(function (t) {
-            var a = anchors[t.name];
-            return { x: a.x * 1.32, y: a.y * 1.32, text: t.name, showarrow: false,
-                     font: { size: 13, color: t.color }, xanchor: "center", yanchor: "middle" };
+        shapes: threads.map(function (t, i) {
+            return { type: "line", x0: i, x1: i, y0: 0.4, y1: -(R - 1) - 0.4,
+                     line: { color: "#ececec", width: 1 }, layer: "below" };
+        }),
+        annotations: threads.map(function (t, i) {
+            return { x: i, y: 1.2, text: t.name, showarrow: false, xanchor: "center", yanchor: "bottom",
+                     font: { size: 12, color: t.color } };
         })
     };
 
-    var el = document.getElementById("pub-landscape");
-    Plotly.newPlot(el, [linkTrace, anchorTrace].concat(pointTraces), layout,
+    Plotly.newPlot(el, [linkTrace].concat(dotTraces), layout,
                    { responsive: true, displayModeBar: false }).then(function () {
         el.on("plotly_click", function (ev) {
             var cd = ev.points[0].customdata; if (!cd) return;

--- a/publications/build.py
+++ b/publications/build.py
@@ -40,6 +40,27 @@ MAILTO = "kevin.jablonka@uni-jena.de"
 HEADERS = {"User-Agent": f"lamalab-publications/1.0 (mailto:{MAILTO})"}
 
 
+LINKS_FILE = HERE / "links.json"
+# DOI prefixes that identify preprint servers (arXiv, ChemRxiv, bioRxiv, Research
+# Square, ChemRxiv legacy) — used to default `type` to "preprint".
+PREPRINT_PREFIXES = ("10.48550/arxiv", "10.26434/chemrxiv", "10.1101/",
+                     "10.21203/", "10.33774/", "10.31223/", "10.31224/")
+
+
+def _is_preprint(doi: str) -> bool:
+    return doi.lower().startswith(PREPRINT_PREFIXES)
+
+
+def load_links() -> dict:
+    """Optional curated media/news links per DOI: {doi: [{label, url}, ...]}."""
+    if not LINKS_FILE.exists():
+        return {}
+    try:
+        return {k.lower(): v for k, v in json.loads(LINKS_FILE.read_text()).items()}
+    except Exception:                                      # noqa: BLE001
+        return {}
+
+
 def load_dotenv() -> None:
     """Load KEY=VALUE pairs from a `.env` (repo root or publications/) into the
     environment, without overriding variables already set. Keeps API keys out of
@@ -363,8 +384,11 @@ def _llm_classify(papers: list[dict]) -> list[list[str]] | None:
         "You assign scientific papers to a research group's threads. The four "
         f"research threads:\n{pillar_block}\n- community: non-research outputs "
         "(editorials, comments, education, perspectives).\n\n"
-        "For each paper below, pick the ONE or TWO threads that genuinely fit "
-        "(prefer one; use two only when a paper substantively spans both). Use "
+        "For each paper, pick ONE or TWO threads. Assign a second thread whenever "
+        "the paper makes a genuine, substantive contribution to it — many of this "
+        "group's papers legitimately span two threads (e.g. a benchmark that is "
+        "also about reasoning, or a method that is both perception and action). "
+        "Use a single thread when the paper is clearly about just one. Use "
         "'community' only for non-research outputs, and then alone.\n\n"
         f"Papers:\n{json.dumps(items, ensure_ascii=False)}\n\n"
         "Respond with ONLY a JSON array, no prose, each element "
@@ -394,14 +418,36 @@ def suggest_pillars(papers: list[dict], texts: list[str]) -> list[list[str]]:
     return [_keyword_pillars(t) for t in texts]
 
 
-def classify_pillars(papers: list[dict], texts: list[str]) -> None:
-    """Fill in pillars for papers lacking an explicit annotation. Mutates in place."""
-    need = [i for i, p in enumerate(papers) if not p.get("pillars")]
+_PILLAR_CACHE = CACHE_DIR / "pillars.json"
+
+
+def classify_pillars(papers: list[dict], texts: list[str], force: bool = False) -> None:
+    """Fill in pillars for papers lacking an explicit annotation. Cached per DOI so
+    rebuilds are stable — only genuinely new papers are (re)classified. Mutates in
+    place."""
+    cache = {}
+    if not force and _PILLAR_CACHE.exists():
+        try:
+            cache = json.loads(_PILLAR_CACHE.read_text())
+        except Exception:                                  # noqa: BLE001
+            cache = {}
+    need = []
+    for i, p in enumerate(papers):
+        if p.get("pillars"):                               # explicit annotation wins
+            continue
+        cached = cache.get(p["doi"].lower())
+        if cached:
+            p["pillars"], p["pillar_auto"] = cached, True
+        else:
+            need.append(i)
     if need:
         suggestions = suggest_pillars([papers[i] for i in need], [texts[i] for i in need])
         for idx, pillars in zip(need, suggestions):
             papers[idx]["pillars"] = pillars or ["community"]
-            papers[idx]["pillar_auto"] = True              # flag for human review
+            papers[idx]["pillar_auto"] = True
+            cache[papers[idx]["doi"].lower()] = papers[idx]["pillars"]
+        CACHE_DIR.mkdir(exist_ok=True)
+        _PILLAR_CACHE.write_text(json.dumps(cache, indent=2, ensure_ascii=False))
 
 
 # --------------------------------------------------------------------------- #
@@ -425,16 +471,19 @@ def main() -> None:
         if rec:
             rec["highlighted"] = entry["highlight"]
             rec["pillars"] = entry["pillars"] or None       # explicit annotation, else LLM fills
-            is_arxiv = rec["doi"].lower().startswith("10.48550/arxiv")
-            rec["type"] = entry["type"] or ("preprint" if is_arxiv else "peer-reviewed")
+            rec["type"] = entry["type"] or ("preprint" if _is_preprint(rec["doi"]) else "peer-reviewed")
             print(f"  ✓ {rec['year']}  {rec['title'][:70]}")
             papers.append(rec)
     if not papers:
         sys.exit("no papers resolved — check the DOIs")
 
+    links = load_links()                                   # curated media/news per DOI
+    for p in papers:
+        p["media"] = links.get(p["doi"].lower(), [])
+
     texts = [f"{p['title']}. {p.get('abstract', '')}".strip() for p in papers]
     print("classifying into research threads ...")
-    classify_pillars(papers, texts)                        # fills any missing pillars
+    classify_pillars(papers, texts, args.force)            # fills any missing pillars
 
     # threads are the group's pillars — canonical order, fixed colours + blurbs
     present = [name for name in PILLAR_ORDER
@@ -443,7 +492,17 @@ def main() -> None:
                 "color": PILLAR_COLOR[name], "description": PILLAR_BLURB[name]}
                for name in present]
 
-    papers.sort(key=lambda p: (-(p["year"] or 0), p["title"].lower()))
+    # order papers so the figure's rows (and the card list) group by primary
+    # thread, singles before multis, multis by their second thread, then by year.
+    order = {name: i for i, name in enumerate(PILLAR_ORDER)}
+
+    def sort_key(p: dict):
+        cols = [order[x] for x in p["pillars"] if x in order] or [0]
+        secondary = max(cols[1:]) if len(cols) > 1 else -1
+        return (cols[0], 1 if len(cols) > 1 else 0, secondary,
+                -(p["year"] or 0), p["title"].lower())
+
+    papers.sort(key=sort_key)
 
     OUT_FILE.parent.mkdir(exist_ok=True)
     OUT_FILE.write_text(json.dumps({"threads": threads, "papers": papers},

--- a/publications/dois.txt
+++ b/publications/dois.txt
@@ -30,6 +30,7 @@
 arXiv:2505.12534                # ChemPile: 250GB dataset for chemical foundation models {type=peer-reviewed, venue=NeurIPS 2025}
 
 # ── preprints ───────────────────────────────────────────────────────────────
+10.26434/chemrxiv.15004102/v2   # Condition-aware prediction of copolymer architecture
 arXiv:2406.17295                # Less can be more for predicting properties with LLMs
 arXiv:2604.18805                # AI scientists produce results without reasoning scientifically
 arXiv:2602.17730                # Clever materials: good materials for the wrong reasons

--- a/publications/links.json
+++ b/publications/links.json
@@ -1,0 +1,23 @@
+{
+  "_comment": "Curated media / news / companion links per DOI (keys are case-insensitive). Shown under each paper. arXiv entries are keyed by their arXiv DOI, e.g. 10.48550/arXiv.2604.18805.",
+
+  "10.1038/s41557-025-01815-x": [
+    { "label": "chembench.lamalab.org", "url": "http://chembench.lamalab.org/" },
+    { "label": "Chemistry World", "url": "https://www.chemistryworld.com/news/large-language-models-are-better-than-humans-at-answering-chemistry-questions/4020562.article" },
+    { "label": "State of AI 2025", "url": "https://www.stateof.ai" },
+    { "label": "research briefing", "url": "https://www.nature.com/articles/s41557-025-01865-1" }
+  ],
+  "10.1038/s42256-023-00788-1": [
+    { "label": "MIT Technology Review", "url": "https://www.technologyreview.com/2023/03/25/1070275/chatgpt-revolutionize-economy-decide-what-looks-like/" },
+    { "label": "Nature News", "url": "https://www.nature.com/articles/d41586-024-00347-7" }
+  ],
+  "10.1038/s43588-025-00836-3": [
+    { "label": "research briefing", "url": "https://www.nature.com/articles/s43588-025-00871-0" }
+  ],
+  "10.1039/d4cs00913d": [
+    { "label": "matextract.pub", "url": "https://matextract.pub/" }
+  ],
+  "10.48550/arxiv.2604.18805": [
+    { "label": "Science News", "url": "https://www.sciencenews.org/article/ai-ignore-evidence-trust-science" }
+  ]
+}


### PR DESCRIPTION
Builds on #41. Reworks the figure, makes classification stable, adds media links, and adds basic SEO.

## Figure → sorted incidence matrix
Threads are **columns**, papers are **rows** (grouped by primary thread); a dot marks each membership and a horizontal line links the threads a paper spans. `build.py` emits papers in that order, so the figure rows and the card list share one coherent ordering. Cleaner than the anchor map and clearer for multi-thread papers.

## Stable, cached classification
LLM thread assignments are now cached per DOI, so rebuilds are deterministic — only genuinely new papers get (re)classified (`--force` redoes all). Also nudged the prompt so papers that truly span two threads get both: **11 of 28** are now multi-thread (ChemBench → evaluation + reasoning, MaCBench → evaluation + perception, …).

## Data
- Added the **Condition-aware copolymer** ChemRxiv preprint.
- Detect preprint DOI prefixes (arXiv / ChemRxiv / bioRxiv / Research Square) for the type tag.

## Cards
- Per-paper **media / news links** from a curated `publications/links.json` (seeded from the group CV — Chemistry World, MIT Tech Review, research briefings, matextract.pub, …).
- Attribution line: metadata from CrossRef / Semantic Scholar / arXiv; **citation counts from Semantic Scholar**.

## Basic SEO
- `baseURL` → **https**, `enableRobotsTXT` (Hugo now emits robots.txt + sitemap.xml).
- Per-page `<meta description>` (publications page mentions Kevin Maik Jablonka).
- **JSON-LD**: an `ItemList` of `ScholarlyArticle` on `/publications`, and `Organization` + `Person` (Kevin Maik Jablonka, with Scholar / ORCID / GitHub / site `sameAs`) on the home page — the main on-page lever for the "kevin jablonka" query.

> Note: structured data + name prominence *helps* Google understand the entity, but ranking #1 for "kevin jablonka" also depends on backlinks/authority and competing sites (his personal site, the university) — it can't be guaranteed from on-page SEO alone.

## Verification
`python publications/build.py` → 28 papers, stable on rebuild (cache hit, no LLM call). `hugo` builds clean; `/publications` renders the matrix, media links, attribution, and valid `ItemList` JSON-LD; the home page emits valid Person/Organization JSON-LD; robots.txt + sitemap.xml generated; canonical URLs are https.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Rework the publications page to use a thread-by-paper incidence matrix with stable thread classification, add curated media links and attribution, and introduce basic SEO/structured data for the site and publications.

New Features:
- Render the publications figure as a threads-by-papers incidence matrix sharing the same ordering as the cards.
- Attach curated per-paper media/news links sourced from a new links.json file and display them on publication cards.
- Emit JSON-LD ItemList structured data for the publications list and Organization/Person structured data on the home page.

Enhancements:
- Make LLM-based research thread classification cached per DOI and deterministic across rebuilds, with an option to force reclassification.
- Improve publication metadata handling by auto-tagging common preprint DOIs and exposing Semantic Scholar citation counts with clearer attribution text.
- Refine publication ordering to group papers by primary thread and multi-thread status for clearer visualization and navigation.
- Update meta descriptions to prefer page-level descriptions and add a specific description for the publications page.

Build:
- Switch the site baseURL to HTTPS and enable automatic robots.txt and sitemap.xml generation for better SEO.