### PR TITLE
Link the group's socials (LinkedIn, X, Bluesky)

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -19,6 +19,22 @@ customHead = ["extra-head.html"]
 [[params.social]]
 name = "github"
 link = "https://github.com/lamalab-org"
+icon = "fab fa-github"
+
+[[params.social]]
+name = "linkedin"
+link = "https://www.linkedin.com/company/lamalab-org"
+icon = "fab fa-linkedin"
+
+[[params.social]]
+name = "x"
+link = "https://x.com/jablonkagroup"
+icon = "fab fa-x-twitter"
+
+[[params.social]]
+name = "bluesky"
+link = "https://bsky.app/profile/jablonkagroup.bsky.social"
+icon = "fab fa-bluesky"
 
 [[menu.main]]
 name = "team"

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -3,4 +3,18 @@
     <section>
         {{ .Content }}
     </section>
+    {{ with .Site.Params.social }}
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.7.2/css/all.min.css">
+    <style>
+        .home-social { display: flex; gap: 1.4rem; margin: 1.5rem 0 0.5rem; font-size: 1.4rem; }
+        .home-social a { color: var(--secondary-color, #666) !important; background: none !important; }
+        .home-social a:hover { color: var(--primary-color, #A43830) !important; }
+    </style>
+    <section class="home-social">
+        {{ range . }}
+        <a href="{{ .link }}" target="_blank" rel="me noopener" aria-label="{{ .name }}" title="{{ .name }}"><i class="{{ .icon | default (printf "fab fa-%s" .name) }}" aria-hidden="true"></i></a>
+        {{ end }}
+    </section>
+    {{ end }}
+</div>
 {{ end }}

--- a/layouts/partials/structured-data.html
+++ b/layouts/partials/structured-data.html
@@ -11,7 +11,12 @@
       "parentOrganization" (dict "@type" "CollegeOrUniversity" "name" "Friedrich Schiller University Jena" "url" "https://www.uni-jena.de/")
       "founder" (dict "@id" (printf "%s#kevin" $base))
       "member" (dict "@id" (printf "%s#kevin" $base))
-      "sameAs" (slice "https://github.com/lamalab-org" "https://lamalaborg.substack.com"))
+      "sameAs" (slice
+        "https://github.com/lamalab-org"
+        "https://www.linkedin.com/company/lamalab-org"
+        "https://x.com/jablonkagroup"
+        "https://bsky.app/profile/jablonkagroup.bsky.social"
+        "https://lamalaborg.substack.com"))
     (dict
       "@type" "Person"
       "@id" (printf "%s#kevin" $base)


### PR DESCRIPTION
Adds the group's social links.

- Home page now shows **GitHub · LinkedIn · X · Bluesky** icons (Font Awesome) under the intro.
- The URLs are also added to the `Organization` `sameAs` in the home-page JSON-LD, which reinforces the entity for search engines.

Links: `linkedin.com/company/lamalab-org`, `x.com/jablonkagroup`, `bsky.app/profile/jablonkagroup.bsky.social` (plus the existing GitHub org).

Verified: `hugo` builds clean; the four icons render with correct brand glyphs and `rel="me noopener"` links, and the structured-data `sameAs` includes all four.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add social media presence links to the home page and structured data for the organization.

New Features:
- Display GitHub, LinkedIn, X, and Bluesky social icons on the home page using site configuration.
- Expose social profile URLs in the Organization JSON-LD sameAs metadata for better discoverability.