### PR TITLE
SEO: brand the site as the Jablonka Group

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -1,4 +1,9 @@
-we apply data-driven techniques to discover materials that work in the real world. through novel machine learning approaches and close collaboration with experimental partners, we bridge the gap between computational predictions and practical applications.
+---
+title: "Jablonka Group · Lab for AI in Materials Science"
+description: "The Jablonka group (LamaLab) of Kevin Maik Jablonka at Friedrich Schiller University Jena — AI and machine learning for chemistry and materials science."
+---
+
+we are the **jablonka group** (lamalab), led by [kevin maik jablonka](https://kjablonka.com) at the [friedrich-schiller-university jena](https://www.uni-jena.de/). we apply data-driven techniques to discover materials that work in the real world. through novel machine learning approaches and close collaboration with experimental partners, we bridge the gap between computational predictions and practical applications.
 
 our group is funded by the carl-zeiss foundation as the "czs research group polymers in energy applications". we are part of the [friedrich-schiller-university jena](https://www.uni-jena.de/) and the [helmholz institute for polymers in energy applications jena](https://www.hipole-jena.de/).
 

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -9,7 +9,7 @@
   {{ end }}
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
-  <title>{{ if .IsPage }} {{ .Title }} | {{ end }}{{ .Site.Title }}</title>
+  <title>{{ if .IsHome }}{{ .Title | default .Site.Title }}{{ else }}{{ .Title }} | {{ .Site.Title }}{{ end }}</title>
   <link rel = 'canonical' href = '{{ .Permalink }}'>
   {{ with (or .Description .Site.Params.description) }}<meta name="description" content="{{ . }}">{{ end }}
   <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/layouts/partials/structured-data.html
+++ b/layouts/partials/structured-data.html
@@ -5,7 +5,7 @@
       "@type" (slice "EducationalOrganization" "ResearchOrganization")
       "@id" (printf "%s#organization" $base)
       "name" .Site.Title
-      "alternateName" (slice "LamaLab" "Laboratory for AI in Materials Science")
+      "alternateName" (slice "Jablonka Group" "Jablonka Research Group" "jablonkagroup" "LamaLab" "Laboratory for AI in Materials Science")
       "url" $base
       "description" .Site.Params.description
       "parentOrganization" (dict "@type" "CollegeOrUniversity" "name" "Friedrich Schiller University Jena" "url" "https://www.uni-jena.de/")
@@ -21,6 +21,7 @@
       "@type" "Person"
       "@id" (printf "%s#kevin" $base)
       "name" "Kevin Maik Jablonka"
+      "alternateName" (slice "Kevin Jablonka" "K. M. Jablonka")
       "givenName" "Kevin Maik"
       "familyName" "Jablonka"
       "jobTitle" "Group Leader"


### PR DESCRIPTION
Names the group on the home page (intro text, `<title>`, meta/OG description) and adds "Jablonka Group / Jablonka Research Group / jablonkagroup" as Organization `alternateName` plus "Kevin Jablonka" as Person `alternateName` in the JSON-LD. On-page signal for the "Jablonka group" branded queries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Brand the site around the Jablonka Group and improve homepage SEO metadata and structured data for organization and person entities.

New Features:
- Add homepage front matter title and description explicitly naming the Jablonka Group and its focus.
- Extend JSON-LD organization alternate names to include Jablonka Group variants and jablonkagroup.
- Add JSON-LD person alternate names for Kevin Maik Jablonka.

Enhancements:
- Update homepage intro copy to foreground the Jablonka Group branding and affiliation details.
- Adjust HTML <title> logic so the homepage uses its own title instead of the generic site title, while preserving existing behavior for other pages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced page metadata with improved title and description fields.

* **Refactor**
  * Optimized page title rendering logic for improved consistency across the site.
  * Expanded organization and person name aliases in structured metadata for better search engine recognition and discoverability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->