### PR TITLE
SEO: add Sitemap line to robots.txt

### DIFF
--- a/layouts/robots.txt
+++ b/layouts/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Disallow:
+
+Sitemap: {{ "sitemap.xml" | absURL }}


### PR DESCRIPTION
robots.txt now points crawlers at the sitemap (`Sitemap: https://lamalab.org/sitemap.xml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enhancements:
- Introduce a robots.txt layout file that includes a Sitemap directive pointing to the public sitemap URL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added robots.txt configuration file to control search engine crawler behavior and specify sitemap location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->