### PR TITLE
SEO: surface Jena / FSU / Helmholtz affiliations

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -3,7 +3,7 @@ title: "Jablonka Group · Lab for AI in Materials Science"
 description: "The Jablonka group (LamaLab) of Kevin Maik Jablonka at Friedrich Schiller University Jena — AI and machine learning for chemistry and materials science."
 ---
 
-we are the **jablonka group** (lamalab), led by [kevin maik jablonka](https://kjablonka.com) at the [friedrich-schiller-university jena](https://www.uni-jena.de/). we apply data-driven techniques to discover materials that work in the real world. through novel machine learning approaches and close collaboration with experimental partners, we bridge the gap between computational predictions and practical applications.
+we are the **jablonka group** (lamalab), led by [kevin maik jablonka](https://kjablonka.com) at [friedrich-schiller-university jena (fsu jena)](https://www.uni-jena.de/) and the [helmholtz institute for polymers in energy applications jena (hipole)](https://www.hipole-jena.de/). we apply data-driven techniques to discover materials that work in the real world. through novel machine learning approaches and close collaboration with experimental partners, we bridge the gap between computational predictions and practical applications.
 
 our group is funded by the carl-zeiss foundation as the "czs research group polymers in energy applications". we are part of the [friedrich-schiller-university jena](https://www.uni-jena.de/) and the [helmholz institute for polymers in energy applications jena](https://www.hipole-jena.de/).
 

--- a/layouts/partials/structured-data.html
+++ b/layouts/partials/structured-data.html
@@ -9,6 +9,7 @@
       "url" $base
       "description" .Site.Params.description
       "parentOrganization" (dict "@type" "CollegeOrUniversity" "name" "Friedrich Schiller University Jena" "url" "https://www.uni-jena.de/")
+      "address" (dict "@type" "PostalAddress" "streetAddress" "Leutragraben 1" "postalCode" "07743" "addressLocality" "Jena" "addressCountry" "DE")
       "founder" (dict "@id" (printf "%s#kevin" $base))
       "member" (dict "@id" (printf "%s#kevin" $base))
       "sameAs" (slice
@@ -26,7 +27,10 @@
       "familyName" "Jablonka"
       "jobTitle" "Group Leader"
       "url" $base
-      "affiliation" (dict "@type" "CollegeOrUniversity" "name" "Friedrich Schiller University Jena" "url" "https://www.uni-jena.de/")
+      "affiliation" (slice
+        (dict "@type" "CollegeOrUniversity" "name" "Friedrich Schiller University Jena" "url" "https://www.uni-jena.de/")
+        (dict "@type" "ResearchOrganization" "name" "Helmholtz Institute for Polymers in Energy Applications Jena (HIPOLE)" "url" "https://www.hipole-jena.de/"))
+      "workLocation" (dict "@type" "Place" "address" (dict "@type" "PostalAddress" "addressLocality" "Jena" "addressCountry" "DE"))
       "worksFor" (dict "@id" (printf "%s#organization" $base))
       "sameAs" (slice
         "https://scholar.google.com/citations?user=R2ntI8IAAAAJ&hl=en"


### PR DESCRIPTION
Makes the page relevant to 'Jablonka Jena' / 'Jablonka FSU' — names FSU Jena + Helmholtz Institute Jena (HIPOLE) in the home intro, and adds a Jena postal address + Person affiliations to the JSON-LD. (HZB intentionally not asserted yet — pending confirmation of the relationship.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Clarify Jablonka group's institutional affiliations with FSU Jena and HIPOLE and enrich structured data for better SEO and discoverability.

New Features:
- Add postal address for the organization in JSON-LD structured data.
- Add multiple institutional affiliations and work location for the person entity in JSON-LD structured data.

Enhancements:
- Update the homepage intro to explicitly reference Friedrich Schiller University Jena (FSU Jena) and the Helmholtz Institute for Polymers in Energy Applications Jena (HIPOLE).