### PR TITLE
SEO: add HZB affiliation (HIPOLE is joint FSU/HZB)

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -3,7 +3,7 @@ title: "Jablonka Group · Lab for AI in Materials Science"
 description: "The Jablonka group (LamaLab) of Kevin Maik Jablonka at Friedrich Schiller University Jena — AI and machine learning for chemistry and materials science."
 ---
 
-we are the **jablonka group** (lamalab), led by [kevin maik jablonka](https://kjablonka.com) at [friedrich-schiller-university jena (fsu jena)](https://www.uni-jena.de/) and the [helmholtz institute for polymers in energy applications jena (hipole)](https://www.hipole-jena.de/). we apply data-driven techniques to discover materials that work in the real world. through novel machine learning approaches and close collaboration with experimental partners, we bridge the gap between computational predictions and practical applications.
+we are the **jablonka group** (lamalab), led by [kevin maik jablonka](https://kjablonka.com) at [friedrich-schiller-university jena (fsu jena)](https://www.uni-jena.de/) and the [helmholtz institute for polymers in energy applications jena (hipole)](https://www.hipole-jena.de/) — a joint institute of fsu jena and the [helmholtz-zentrum berlin (hzb)](https://www.helmholtz-berlin.de/). we apply data-driven techniques to discover materials that work in the real world. through novel machine learning approaches and close collaboration with experimental partners, we bridge the gap between computational predictions and practical applications.
 
 our group is funded by the carl-zeiss foundation as the "czs research group polymers in energy applications". we are part of the [friedrich-schiller-university jena](https://www.uni-jena.de/) and the [helmholz institute for polymers in energy applications jena](https://www.hipole-jena.de/).
 

--- a/layouts/partials/structured-data.html
+++ b/layouts/partials/structured-data.html
@@ -29,7 +29,8 @@
       "url" $base
       "affiliation" (slice
         (dict "@type" "CollegeOrUniversity" "name" "Friedrich Schiller University Jena" "url" "https://www.uni-jena.de/")
-        (dict "@type" "ResearchOrganization" "name" "Helmholtz Institute for Polymers in Energy Applications Jena (HIPOLE)" "url" "https://www.hipole-jena.de/"))
+        (dict "@type" "ResearchOrganization" "name" "Helmholtz Institute for Polymers in Energy Applications Jena (HIPOLE)" "url" "https://www.hipole-jena.de/")
+        (dict "@type" "ResearchOrganization" "name" "Helmholtz-Zentrum Berlin (HZB)" "url" "https://www.helmholtz-berlin.de/"))
       "workLocation" (dict "@type" "Place" "address" (dict "@type" "PostalAddress" "addressLocality" "Jena" "addressCountry" "DE"))
       "worksFor" (dict "@id" (printf "%s#organization" $base))
       "sameAs" (slice


### PR DESCRIPTION
HIPOLE is a joint institute of FSU Jena and Helmholtz-Zentrum Berlin, so the HZB tie is accurate. Names HZB on the home page and adds it to the Person affiliations in the JSON-LD — relevant to the 'Jablonka HZB' query.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add Helmholtz-Zentrum Berlin (HZB) as an additional affiliation for the group and its members for improved accuracy and SEO.

New Features:
- Expose Helmholtz-Zentrum Berlin (HZB) as an additional affiliation in the JSON-LD structured data for persons.
- Mention HIPOLE's joint affiliation with HZB on the home page content.