### PR TITLE
Feat/weekly publications sync

### DIFF
--- a/.github/workflows/build-publications.yml
+++ b/.github/workflows/build-publications.yml
@@ -1,11 +1,10 @@
 name: Rebuild publications data
 
-# lamalab-org/outputs sends an `outputs-pull-request` repository dispatch when a
-# pull request closes. Only merged pull requests are allowed to start the rebuild.
-# The manual trigger remains available for forced metadata refreshes.
+# Pull the canonical catalogue from the private lamalab-org/outputs repository
+# once a week. Manual runs remain available for testing and forced refreshes.
 on:
-  repository_dispatch:
-    types: [outputs-pull-request]
+  schedule:
+    - cron: "0 6 * * 1" # Mondays at 06:00 UTC
   workflow_dispatch:
     inputs:
       force:
@@ -23,20 +22,35 @@ concurrency:
 
 jobs:
   rebuild:
-    if: >-
-      github.event_name == 'workflow_dispatch' ||
-      (github.event.client_payload.repository.full_name == 'lamalab-org/outputs' &&
-      github.event.client_payload.action == 'closed' &&
-      github.event.client_payload.pull_request.merged == true)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout website
+        uses: actions/checkout@v4
 
-      - name: Prepare upstream publications list
-        if: github.event_name == 'repository_dispatch'
-        run: >-
-          jq -r '.client_payload.publications_yaml'
-          "$GITHUB_EVENT_PATH" > "$RUNNER_TEMP/outputs-publications.yaml"
+      - name: Check sync token
+        env:
+          SYNC_TOKEN: >-
+            ${{ secrets.PUBLICATION_SYNC_TOKEN || secrets.OUTPUTS_TOKEN }}
+        run: |
+          if [[ -z "$SYNC_TOKEN" ]]; then
+            echo "::error::PUBLICATION_SYNC_TOKEN or OUTPUTS_TOKEN is not configured"
+            exit 1
+          fi
+
+      - name: Checkout outputs catalogue
+        uses: actions/checkout@v4
+        with:
+          repository: lamalab-org/outputs
+          token: ${{ secrets.PUBLICATION_SYNC_TOKEN || secrets.OUTPUTS_TOKEN }}
+          path: upstream-outputs
+          persist-credentials: false
+
+      - name: Check publications catalogue
+        run: |
+          if [[ ! -r upstream-outputs/outputs/publications.yaml ]]; then
+            echo "::error::outputs/publications.yaml is missing or unreadable"
+            exit 1
+          fi
 
       - uses: actions/setup-python@v5
         with:
@@ -51,11 +65,9 @@ jobs:
           # ANTHROPIC_API_KEY -> Claude assigns each paper to one or two threads.
           # Optional: without it the script falls back to a keyword heuristic.
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          OUTPUTS_FILE: ${{ github.event_name == 'repository_dispatch' && format('{0}/outputs-publications.yaml', runner.temp) || '' }}
           FORCE_REFRESH: ${{ github.event_name == 'workflow_dispatch' && inputs.force || false }}
         run: |
-          args=()
-          [[ -n "$OUTPUTS_FILE" ]] && args+=(--outputs-file "$OUTPUTS_FILE")
+          args=(--outputs-file upstream-outputs/outputs/publications.yaml)
           [[ "$FORCE_REFRESH" == "true" ]] && args+=(--force)
           python publications/build.py "${args[@]}"
 
@@ -66,9 +78,8 @@ jobs:
           title: "Refresh publications data"
           commit-message: "chore: refresh data/publications.json"
           body: |
-            Automated rebuild of the publications landscape.
-
-            ${{ github.event_name == 'repository_dispatch' && format('Triggered by lamalab-org/outputs pull request #{0}: {1}', github.event.client_payload.pull_request.number, github.event.client_payload.pull_request.html_url) || 'Triggered manually.' }}
+            Weekly automated rebuild of the publications landscape from
+            `lamalab-org/outputs/outputs/publications.yaml`.
 
             **Review before merging** — in particular the auto-generated topic names
             (edit them in `data/publications.json`; renames are preserved on the next run).

--- a/.github/workflows/build-publications.yml
+++ b/.github/workflows/build-publications.yml
@@ -1,9 +1,11 @@
 name: Rebuild publications data
 
-# Manual trigger only — the publications landscape is expensive to compute, so it
-# is regenerated on demand (not on every site build). The job opens a pull request
-# with the refreshed data/publications.json for human review before it goes live.
+# lamalab-org/outputs sends an `outputs-pull-request` repository dispatch when a
+# pull request closes. Only merged pull requests are allowed to start the rebuild.
+# The manual trigger remains available for forced metadata refreshes.
 on:
+  repository_dispatch:
+    types: [outputs-pull-request]
   workflow_dispatch:
     inputs:
       force:
@@ -15,11 +17,26 @@ permissions:
   contents: write
   pull-requests: write
 
+concurrency:
+  group: publications-data
+  cancel-in-progress: false
+
 jobs:
   rebuild:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.client_payload.repository.full_name == 'lamalab-org/outputs' &&
+      github.event.client_payload.action == 'closed' &&
+      github.event.client_payload.pull_request.merged == true)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      - name: Prepare upstream publications list
+        if: github.event_name == 'repository_dispatch'
+        run: >-
+          jq -r '.client_payload.publications_yaml'
+          "$GITHUB_EVENT_PATH" > "$RUNNER_TEMP/outputs-publications.yaml"
 
       - uses: actions/setup-python@v5
         with:
@@ -34,16 +51,24 @@ jobs:
           # ANTHROPIC_API_KEY -> Claude assigns each paper to one or two threads.
           # Optional: without it the script falls back to a keyword heuristic.
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-        run: python publications/build.py ${{ inputs.force && '--force' || '' }}
+          OUTPUTS_FILE: ${{ github.event_name == 'repository_dispatch' && format('{0}/outputs-publications.yaml', runner.temp) || '' }}
+          FORCE_REFRESH: ${{ github.event_name == 'workflow_dispatch' && inputs.force || false }}
+        run: |
+          args=()
+          [[ -n "$OUTPUTS_FILE" ]] && args+=(--outputs-file "$OUTPUTS_FILE")
+          [[ "$FORCE_REFRESH" == "true" ]] && args+=(--force)
+          python publications/build.py "${args[@]}"
 
       - name: Open pull request with refreshed data
         uses: peter-evans/create-pull-request@v6
         with:
           branch: bot/publications-data
           title: "Refresh publications data"
-          commit-message: "chore: refresh data/publications.json from dois.txt"
+          commit-message: "chore: refresh data/publications.json"
           body: |
-            Automated rebuild of the publications landscape from `publications/dois.txt`.
+            Automated rebuild of the publications landscape.
+
+            ${{ github.event_name == 'repository_dispatch' && format('Triggered by lamalab-org/outputs pull request #{0}: {1}', github.event.client_payload.pull_request.number, github.event.client_payload.pull_request.html_url) || 'Triggered manually.' }}
 
             **Review before merging** — in particular the auto-generated topic names
             (edit them in `data/publications.json`; renames are preserved on the next run).

--- a/publications/build.py
+++ b/publications/build.py
@@ -28,6 +28,7 @@ import os
 import re
 import sys
 import time
+from collections.abc import Mapping
 from pathlib import Path
 
 import requests
@@ -177,15 +178,23 @@ def read_outputs(path: Path) -> list[dict]:
         sys.exit("PyYAML is required when --outputs-file is used")
 
     try:
-        document = yaml.safe_load(path.read_text()) or {}
+        document = yaml.safe_load(path.read_text())
     except (OSError, yaml.YAMLError) as e:
         sys.exit(f"could not read outputs publications file {path}: {e}")
+    if not isinstance(document, Mapping):
+        sys.exit(f"invalid outputs publications file {path}: top level must be a mapping")
+    outputs = document.get("outputs", [])
+    if not isinstance(outputs, list):
+        sys.exit(f"invalid outputs publications file {path}: 'outputs' must be a list")
 
     curated = ({entry["doi"].lower(): entry for entry in read_dois()}
                if DOIS_FILE.exists() else {})
     type_map = {"paper": "peer-reviewed", "preprint": "preprint", "editorial": "editorial"}
     entries, seen = [], set()
-    for output in document.get("outputs", []):
+    for index, output in enumerate(outputs, start=1):
+        if not isinstance(output, Mapping):
+            sys.exit(f"invalid outputs publications file {path}: "
+                     f"'outputs' item {index} must be a mapping")
         ident = output.get("doi") or (f"arXiv:{output['arxiv']}" if output.get("arxiv") else "")
         entry = _parse_identifier(str(ident))
         if not entry:

--- a/publications/build.py
+++ b/publications/build.py
@@ -181,7 +181,8 @@ def read_outputs(path: Path) -> list[dict]:
     except (OSError, yaml.YAMLError) as e:
         sys.exit(f"could not read outputs publications file {path}: {e}")
 
-    curated = {entry["doi"].lower(): entry for entry in read_dois()}
+    curated = ({entry["doi"].lower(): entry for entry in read_dois()}
+               if DOIS_FILE.exists() else {})
     type_map = {"paper": "peer-reviewed", "preprint": "preprint", "editorial": "editorial"}
     entries, seen = [], set()
     for output in document.get("outputs", []):
@@ -195,9 +196,10 @@ def read_outputs(path: Path) -> list[dict]:
         seen.add(key)
 
         local = curated.get(key, {})
+        raw_type = str(output.get("type", "")).lower()
         entry["pillars"] = local.get("pillars", [])
         entry["venue"] = local.get("venue") or output.get("venue")
-        entry["type"] = local.get("type") or type_map.get(str(output.get("type", "")).lower())
+        entry["type"] = local.get("type") or type_map.get(raw_type, raw_type or None)
         entry["role"] = local.get("role")
         entry["highlight"] = bool(local.get("highlight") or output.get("highlight"))
         entries.append(entry)

--- a/publications/build.py
+++ b/publications/build.py
@@ -10,13 +10,15 @@ Classification degrades gracefully: a strong LLM reads the abstract
 (ANTHROPIC_API_KEY) -> keyword heuristic. An explicit pillar in dois.txt always
 wins. The figure is anchored on the pillars (no embeddings needed).
 
-Human review = edit data/publications.json directly. Re-runs preserve human-renamed
-topics by matching each new cluster to the prior topic with the most DOIs in common.
-Paper inclusion is driven solely by dois.txt.
+Human review = edit data/publications.json directly. Local annotations in dois.txt
+remain authoritative. Paper inclusion normally comes from dois.txt; automated syncs
+can instead supply lamalab-org/outputs/outputs/publications.yaml.
 
 Usage:
     python build.py            # uses on-disk cache for network fetches
     python build.py --force    # ignore cache, re-fetch everything
+    python build.py --outputs-file publications.yaml
+                               # use lamalab-org/outputs as the publication list
 """
 from __future__ import annotations
 
@@ -121,8 +123,24 @@ def _parse_annotations(comment: str) -> dict:
     return ann
 
 
-def read_dois() -> list[dict]:
-    """Parse dois.txt. Each line is a DOI (or `arXiv:ID`) plus an optional
+def _parse_identifier(ident: str, comment: str = "") -> dict | None:
+    """Normalize one DOI/arXiv identifier and its optional annotation comment."""
+    ident = ident.strip()
+    doi = re.sub(r"^https?://(dx\.)?doi\.org/", "", ident, flags=re.I)
+    if not doi:
+        return None
+    # arXiv entries: accept `arXiv:2505.12534`, an abs URL, or the arXiv DOI.
+    arxiv = None
+    m_ax = (re.match(r"(?:arxiv:|https?://arxiv\.org/abs/)(\d{4}\.\d{4,5}(?:v\d+)?)$", ident, re.I)
+            or re.match(r"10\.48550/arxiv\.(\d{4}\.\d{4,5}(?:v\d+)?)$", doi, re.I))
+    if m_ax:
+        arxiv = m_ax.group(1)
+        doi = f"10.48550/arXiv.{arxiv.split('v')[0]}"
+    return {"doi": doi, "arxiv": arxiv, **_parse_annotations(comment)}
+
+
+def read_dois(path: Path = DOIS_FILE) -> list[dict]:
+    """Parse a curated DOI file. Each line is a DOI (or `arXiv:ID`) plus an optional
     `# comment` that may carry curated annotations inside braces, e.g.
 
         10.1038/s41557-025-01815-x   # ChemBench {evaluation, corresponding, highlight}
@@ -131,28 +149,59 @@ def read_dois() -> list[dict]:
     Recognised: a pillar (perception|reasoning|evaluation|action), a role
     (corresponding|first|coauthor), `highlight`, and `venue=...`. These come from
     human curation (the source of truth) and flow straight into the output."""
-    if not DOIS_FILE.exists():
-        sys.exit(f"missing {DOIS_FILE}")
+    if not path.exists():
+        sys.exit(f"missing {path}")
     out, seen = [], set()
-    for raw in DOIS_FILE.read_text().splitlines():
+    for raw in path.read_text().splitlines():
         doi_part, _, comment = raw.partition("#")
-        ident = doi_part.strip()
-        doi = re.sub(r"^https?://(dx\.)?doi\.org/", "", ident, flags=re.I)
-        if not doi:
+        entry = _parse_identifier(doi_part, comment)
+        if not entry:
             continue
-        # arXiv entries: accept `arXiv:2505.12534`, an abs URL, or the arXiv DOI.
-        arxiv = None
-        m_ax = (re.match(r"(?:arxiv:|https?://arxiv\.org/abs/)(\d{4}\.\d{4,5}(?:v\d+)?)$", ident, re.I)
-                or re.match(r"10\.48550/arxiv\.(\d{4}\.\d{4,5}(?:v\d+)?)$", doi, re.I))
-        if m_ax:
-            arxiv = m_ax.group(1)
-            doi = f"10.48550/arXiv.{arxiv.split('v')[0]}"
-        ann = _parse_annotations(comment)
-        key = doi.lower()
+        key = entry["doi"].lower()
         if key not in seen:
             seen.add(key)
-            out.append({"doi": doi, "arxiv": arxiv, **ann})
+            out.append(entry)
     return out
+
+
+def read_outputs(path: Path) -> list[dict]:
+    """Read the publications list from lamalab-org/outputs.
+
+    Matching entries in the local dois.txt keep their curated pillar, venue, and
+    type annotations. Upstream owns inclusion plus the default publication type
+    and highlight flag.
+    """
+    try:
+        import yaml
+    except ImportError:
+        sys.exit("PyYAML is required when --outputs-file is used")
+
+    try:
+        document = yaml.safe_load(path.read_text()) or {}
+    except (OSError, yaml.YAMLError) as e:
+        sys.exit(f"could not read outputs publications file {path}: {e}")
+
+    curated = {entry["doi"].lower(): entry for entry in read_dois()}
+    type_map = {"paper": "peer-reviewed", "preprint": "preprint", "editorial": "editorial"}
+    entries, seen = [], set()
+    for output in document.get("outputs", []):
+        ident = output.get("doi") or (f"arXiv:{output['arxiv']}" if output.get("arxiv") else "")
+        entry = _parse_identifier(str(ident))
+        if not entry:
+            continue
+        key = entry["doi"].lower()
+        if key in seen:
+            continue
+        seen.add(key)
+
+        local = curated.get(key, {})
+        entry["pillars"] = local.get("pillars", [])
+        entry["venue"] = local.get("venue") or output.get("venue")
+        entry["type"] = local.get("type") or type_map.get(str(output.get("type", "")).lower())
+        entry["role"] = local.get("role")
+        entry["highlight"] = bool(local.get("highlight") or output.get("highlight"))
+        entries.append(entry)
+    return entries
 
 
 # --------------------------------------------------------------------------- #
@@ -457,12 +506,14 @@ def main() -> None:
     ap = argparse.ArgumentParser()
     ap.add_argument("--force", action="store_true",
                     help="ignore cache, re-fetch all metadata")
+    ap.add_argument("--outputs-file", type=Path,
+                    help="lamalab-org/outputs publications.yaml to use for inclusion")
     args = ap.parse_args()
 
     load_dotenv()
-    entries = read_dois()
+    entries = read_outputs(args.outputs_file) if args.outputs_file else read_dois()
     if not entries:
-        sys.exit("dois.txt is empty — add at least one DOI")
+        sys.exit("publication input is empty — add at least one DOI or arXiv ID")
     print(f"fetching metadata for {len(entries)} DOIs ...")
 
     papers = []

--- a/publications/requirements.txt
+++ b/publications/requirements.txt
@@ -1,6 +1,7 @@
 # Dependencies for publications/build.py — intentionally tiny.
 requests            # metadata + abstracts from CrossRef / Semantic Scholar / arXiv
 anthropic           # LLM thread classification (needs ANTHROPIC_API_KEY)
+PyYAML               # parse the canonical lamalab-org/outputs publication list
 
 # Classification falls back to a keyword heuristic if anthropic / the key is
 # absent. The figure is anchored on the pillars, so no embedding model is needed.


### PR DESCRIPTION
## Summary by Sourcery

Sync the publications catalogue weekly from the canonical lamalab-org/outputs repository while preserving local curation, and wire this into the publications build pipeline and CI workflow.

New Features:
- Allow publications/build.py to consume a publications list from lamalab-org/outputs via a new --outputs-file option.
- Support ingesting publications from a YAML catalogue, including DOI/arXiv normalization and merging with locally curated annotations.

Enhancements:
- Refactor DOI/arXiv parsing into a reusable helper and generalize the curated DOI reader to accept an explicit path parameter.

Build:
- Add PyYAML as a dependency for parsing the upstream publications YAML file.

CI:
- Extend the publications rebuild workflow to run weekly, pull the outputs catalogue from lamalab-org/outputs, and use it as the source of inclusion while preserving manual dispatch for forced refreshes.